### PR TITLE
Notify matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,18 @@ Will be computed using the [Monarch Phenotype Profile Analysis tool](https://mon
 
 - **Disorders**
 OMIM diagnoses, if available, will make up **1/4 of the maximum similarity score**.
+<br>
 
+## Enabling match notifications
+
+Email notification of patient matching can be enabled by editing the email notification parameters
+in the configuration file (config.py).
+Once these parameters are set to valid values an email notification will be sent in the following cases:
+
+ - A patient is added to the database and the add request triggers a search on external nodes producing at least one result (/patient/add endpoint).
+ - An external search is actively performed on connected nodes and returns at least one result (/match/external/<patient_id> endpoint).
+ - The server is interrogated by an external node and returns at least one result match (/match endpoint). In this case a match notification is sent to each contact of the result matches.
+ - An internal search is submitted to the server using a patient from the database (/match endpoint) and this search returns at least one match. In this case contact users of all patients involved will be notified (contact from query patient and contacts from the result patients).
 
 
 [travis-url]: https://travis-ci.org/Clinical-Genomics/patientMatcher

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ OMIM diagnoses, if available, will make up **1/4 of the maximum similarity score
 
 Email notification of patient matching can be enabled by editing the email notification parameters
 in the configuration file (config.py).
-Once these parameters are set to valid values an email notification will be sent in the following cases:
+Once these parameters are set to valid values a notification email will be sent in the following cases:
 
  - A patient is added to the database and the add request triggers a search on external nodes producing at least one result (/patient/add endpoint).
  - An external search is actively performed on connected nodes and returns at least one result (/match/external/<patient_id> endpoint).

--- a/instance/config.py
+++ b/instance/config.py
@@ -19,3 +19,11 @@ MAX_PHENO_SCORE = 0.5
 
 # Max results matches returned by server.
 MAX_RESULTS = 5
+
+# Email notification params.
+# Required only if you want to send match notifications to patients contacts
+MAIL_SERVER = smtp_server
+MAIL_PORT = mail_port
+MAIL_USE_SSL = True/False
+MAIL_USERNAME = mail_username
+MAIL_PASSWORD = mail_password

--- a/instance/config.py
+++ b/instance/config.py
@@ -22,8 +22,8 @@ MAX_RESULTS = 5
 
 # Email notification params.
 # Required only if you want to send match notifications to patients contacts
-MAIL_SERVER = smtp_server
-MAIL_PORT = mail_port
-MAIL_USE_SSL = True/False
-MAIL_USERNAME = mail_username
-MAIL_PASSWORD = mail_password
+#MAIL_SERVER = smtp_server
+#MAIL_PORT = mail_port
+#MAIL_USE_SSL = True or False
+#MAIL_USERNAME = mail_username
+#MAIL_PASSWORD = mail_password

--- a/patientMatcher/__init__.py
+++ b/patientMatcher/__init__.py
@@ -3,6 +3,7 @@ import os
 from pymongo import MongoClient
 import logging
 from flask import Flask
+from flask_mail import Mail
 
 logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger(__name__)
@@ -12,22 +13,16 @@ def create_app():
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_pyfile('config.py')
 
-    if not app.config.get('DB_URI') or not app.config.get('DB_NAME'):
-        LOG.error('Please use values for DB_URI and DB_NAME parameters in config file.')
-        return None
-
-    if not app.config.get('MAX_GT_SCORE') or not app.config.get('MAX_PHENO_SCORE') or not (app.config.get('MAX_PHENO_SCORE') + app.config.get('MAX_GT_SCORE')) == 1:
-        LOG.error('Please chech that MAX_GT_SCORE and MAX_PHENO_SCORE have valid values')
-        return None
-
-    if not app.config.get('MAX_RESULTS') or not isinstance(app.config.get('MAX_RESULTS'), int):
-        LOG.error('MAX_RESULTS parameter in config file must be a number')
-        return None
-
     client = MongoClient(app.config['DB_URI'])
     app.db = client[app.config['DB_NAME']]
+
+    if app.config.get('MAIL_SERVER'):
+        mail = Mail(app)
+        app.mail = mail
+
     app.register_blueprint(server.views.blueprint)
     return app
+
 
 
 def run_app():

--- a/patientMatcher/__init__.py
+++ b/patientMatcher/__init__.py
@@ -34,6 +34,8 @@ def run_app():
     else:
         LOG.error('Fix config issues before running the app')
 
+    return app
+
 
 if __name__ == '__main__':
     create_app()

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -33,7 +33,8 @@ def match_external(database, query_patient):
     matching_obj = external_matcher(database, query_patient)
     # save matching object to database
     database['matches'].insert_one(matching_obj)
-    return matching_obj.get('results'), matching_obj.get('errors')
+
+    return matching_obj
 
 
 def check_request(database, request):

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -8,7 +8,7 @@ from flask_negotiate import consumes, produces
 
 from patientMatcher import create_app
 from patientMatcher.utils.add import backend_add_patient
-from patientMatcher.utils.notify import notify_match_external
+from patientMatcher.utils.notify import notify_match_external, notify_match_internal
 from patientMatcher.auth.auth import authorize
 from patientMatcher.match.handler import internal_matcher, patient_matches
 from patientMatcher.parse.patient import validate_api, mme_patient
@@ -164,9 +164,10 @@ def match_internal():
     current_app.db['matches'].insert_one(match_obj)
     matches = match_obj['results']
 
-    # if notifications are on and there are results
-    #if current_app.config.get('ADMIN_EMAIL') and len(results):
-
+    # if notifications are on and there are matching results
+    if current_app.config.get('MAIL_SERVER') and len(matches):
+        notify_match_internal(database=current_app.db, match_obj=match_obj,
+            admin_email=current_app.config.get('MAIL_USERNAME'), mail=current_app.mail)
 
 
     validate_response = controllers.validate_response({'results': matches})

--- a/patientMatcher/utils/add.py
+++ b/patientMatcher/utils/add.py
@@ -62,6 +62,8 @@ def backend_add_patient(mongo_db, patient, match_external=False):
     """
     modified = None
     upserted = None
+    matching_obj = None
+
     try:
         result = mongo_db['patients'].replace_one({'_id': patient['_id']}, patient , upsert=True)
         modified = result.modified_count
@@ -78,7 +80,7 @@ def backend_add_patient(mongo_db, patient, match_external=False):
         #save matching object to database
         mongo_db['matches'].insert_one(matching_obj)
 
-    return modified, upserted
+    return modified, upserted, matching_obj
 
 
 def add_node(mongo_db, obj, is_client):

--- a/patientMatcher/utils/notify.py
+++ b/patientMatcher/utils/notify.py
@@ -1,23 +1,122 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from flask_mail import Message
 
 LOG = logging.getLogger(__name__)
 
-def notify_match(match_obj, admin_email, query_patient, external_match=False):
-    """Send an email to patient contact to notify a match
+
+def notify_match_internal(database, match_obj, admin_email):
+    """Send an email to patient contacts after an internal match
 
     Args:
         match_obj(dict): an object containing both query patient(dict) and matching results(list)
-        admin_email(str): email of sender
-        query_patient(dict): patient object used for the query
-        external_match(bool): True == match in connected nodes, False == match with other patients in database
+        admin_email(str): email of the server admin
+    """
+    # Internal matching can be triggered by a patient in the same database or by a patient on a connected node.
+    # In the first case notify both querier contact and contacts in the result patients.
+    # in the second case notify only contacts from patients in the results list.
 
-    Returns:
-        Boh!
+    # check if query patient belongs to patientMatcher database:
+    #results = database['patients'].find_one( {'_id':match_obj['data']['patient']['id']} )
+    #if len()
+
+    return "Nothing!"
+
+
+
+def notify_match_external(match_obj, admin_email, mail):
+    """Send an email to patients contacts to notify a match on external nodes
+
+    Args:
+        match_obj(dict): an object containing both query patient(dict) and matching results(list)
+        admin_email(str): email of the server admin
+        mail(flask_mail.Mail): an email instance
     """
 
-    if 
+    sender = admin_email
+    patient_id = match_obj['data']['patient']['id']
+    patient_label = match_obj['data']['patient'].get('label')
+    results = match_obj['results']
+    recipient = match_obj['data']['patient']['contact']['href'][7:]
+    email_subject = 'MatchMaker Exchange: new patient match available.'
+    email_body = active_match_email_body(patient_id, results, patient_label, external_match=True)
+    LOG.info('Sending a match notification to patient contact {}'.format(recipient))
+
+    kwargs = dict(subject=email_subject, html=email_body, sender=sender, recipients=[recipient])
+    message = Message(**kwargs)
+    # send email using flask_mail
+    mail.send(message)
+
+    """
+    else:
+        # a match request (external or internal) was sent to server and has results.
+        # loop over patient list in results and for each patient notify its contact about it
+        for result in match_obj.get('results'):
+            patient_id = result['patient']['id']
+            patient_label = result['patient'].get('label')
+            recipient = result['patient']['contact']['href'][8:]
+            email_body = notification_body(patient_id, patient_label, external_match)
+
+            kwargs = dict(subject=email_subject, html=email_body, sender=sender, recipients=recipients)
+            message = Message(**kwargs)
+            # send email using flask_mail
+            mail.send(message)
+    """
+
+def active_match_email_body(patient_id, results, patient_label=None, external_match=False):
+    """Returns the body message of the notification email when the patient was used as query patient
+
+    Args:
+        patient_id(str): the ID of the patient submitted by the  MME user which will be notified
+        external_match(bool): True == match in connected nodes, False == match with other patients in database
+        results(list): a list of patients which match with the patient whose contact is going to be notified
+        patient_label(str): the label of the patient submitted by the  MME user which will be notified (not mandatory field)
 
 
-def email_body():
+    Returns:
+        html(str): the body message
+    """
+    search_type = 'against the internal database of MatchMaker patients'
+    if external_match:
+        search_type = 'against external nodes connected to MatchMaker'
+
+    html = """
+        ***This is an automated message, please do not reply to this email.***<br><br>
+        <strong>MatchMaker Exchange patient matching notification:</strong><br><br>
+        Patient with ID <strong>{0}</strong>, label <strong>{1}</strong> was recently used in a search {2}.
+        This search returned <strong>{3} potential matches</strong>.<br><br>
+        For security reasons match results and patient contacts are not disclosed in this email.<br>
+        Please contact the service provider or connect to the portal you used to submit the data to review these results.
+        <br><br>
+        Kind regards,<br>
+        The PatienMatcher team
+    """.format(patient_id, patient_label, search_type, len(results))
+
+    return html
+
+
+def passive_match_email_body(patient_id, patient_label=None):
+    """Returns the body message of the notification email when the patient was used as query patient
+
+    Args:
+        patient_id(str): the ID of the patient submitted by the  MME user which will be notified
+        patient_label(str): the label of the patient submitted by the  MME user which will be notified (not mandatory field)
+
+    Returns:
+        html(str): the body message
+    """
+
+    html = """
+        ***This is an automated message, please do not reply.***<br>
+        <strong>MatchMaker Exchange patient matching notification:</strong><br><br>
+        Patient with <strong>ID {0}</strong>,<strong> label {1}</strong> was recently returned as a match result
+        in a search performed using a patient stored in the same MatchMaker node.
+        For security reasons match results and patient contacts are not disclosed in this email.<br>
+        Please contact the service provider or connect to the portal you used to submit the data to review these results.
+        <br><br>
+        Kind regards,<br>
+        The PatienMatcher team
+    """.format(patient_id, label)
+
+    return html

--- a/patientMatcher/utils/notify.py
+++ b/patientMatcher/utils/notify.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+LOG = logging.getLogger(__name__)
+
+def notify_match(match_obj, admin_email, query_patient, external_match=False):
+    """Send an email to patient contact to notify a match
+
+    Args:
+        match_obj(dict): an object containing both query patient(dict) and matching results(list)
+        admin_email(str): email of sender
+        query_patient(dict): patient object used for the query
+        external_match(bool): True == match in connected nodes, False == match with other patients in database
+
+    Returns:
+        Boh!
+    """
+
+    if 
+
+
+def email_body():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ## server
 Flask
+Flask-Mail
 flask_negotiate
 requests
 jsonschema

--- a/tests/backend/test_backend_patient.py
+++ b/tests/backend/test_backend_patient.py
@@ -26,7 +26,7 @@ def test_load_demo_patients(demo_data_path, database):
     assert len(inserted_ids) == 0
 
 
-def test_backend_remove_patient(json_patients, database, match_obs):
+def test_backend_remove_patient(json_patients, database):
     """ Test adding 2 test patients and then removing them using label or ID """
 
     # test conversion to format required for the database:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -116,7 +116,7 @@ def test_cli_add_demo_data(database):
     assert database['patients'].find().count() == 50
 
 
-def test_cli_remove_patient(database, json_patients, match_obs):
+def test_cli_remove_patient(database, json_patients, match_objs):
     app.db = database
     runner = app.test_cli_runner()
 
@@ -134,7 +134,7 @@ def test_cli_remove_patient(database, json_patients, match_obs):
     assert 'Error' in result.output
 
     # Add mock patient matches objects to database
-    database['matches'].insert_many(match_obs)
+    database['matches'].insert_many(match_objs)
     # There should be 2 matches in database for this patient:
     assert database['matches'].find( {'data.patient.id' : inserted_id }).count() == 2
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,22 @@ from pathlib import Path
 
 DATABASE = 'testdb'
 
+class MockMail:
+    _send_was_called = False
+    _message = None
+
+    def send(self, message):
+        self._send_was_called = True
+        self._message = message
+
+@pytest.fixture
+def mock_mail():
+    return MockMail()
+
+@pytest.fixture
+def mock_sender():
+    return 'mock_sender'
+
 @pytest.fixture(scope='function')
 def pymongo_client(request):
     """Get a client to the mongo database"""
@@ -64,7 +80,10 @@ def match_obs():
             'has_matches' : True,
             'data' : {
                 'patient' : {
-                    'id' : 'P0000079'
+                    'id' : 'P0000079',
+                    'contact' : {
+                        'href' : 'mailto:test_contact@email.com'
+                    }
                 }
             },
             'results' : [
@@ -79,6 +98,9 @@ def match_obs():
             'data' : {
                 'patient' : {
                     'id' : 'P0000079'
+                },
+                'contact' : {
+                    'href' : 'mailto:test_contact@email.com'
                 }
             },
             'results' : [],
@@ -89,11 +111,19 @@ def match_obs():
             'has_matches' : True,
             'data' : {
                 'patient' : {
-                    'id' : 'external_patient_1'
+                    'id' : 'external_patient_1',
+                    'contact' : {
+                        'href' : 'mailto:test_contact@email.com'
+                    }
                 }
             },
             'results' : [
-                {'patient' : { 'id' : 'P0000079'}},
+                {'patient' : {
+                    'id' : 'P0000079',
+                    'contact' : {
+                        'href' : 'mailto:test_contact2@email.com'
+                    }
+                }},
             ],
             'match_type' : 'internal'
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def test_node():
 
 
 @pytest.fixture(scope='function')
-def match_obs():
+def match_objs():
     """Mock the results of an internal and an external match"""
     matches = [
         {    # External match where test_patient is the query and with results

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from patientMatcher import run_app
+
+def test_run_app():
+    app = run_app()
+    assert app

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -95,7 +95,7 @@ def test_patient_view(database, test_client):
     assert auth_response.status_code == 200
 
 
-def test_delete_patient(database, demo_data_path, test_client, match_obs):
+def test_delete_patient(database, demo_data_path, test_client, match_objs):
     """Test deleting a patient from database by sending a DELETE request"""
 
     app.db = database
@@ -124,7 +124,7 @@ def test_delete_patient(database, demo_data_path, test_client, match_obs):
 
     assert database['matches'].find().count() == 0 # no matches in database
     # insert into database some mock matching objects
-    database['matches'].insert_many(match_obs)
+    database['matches'].insert_many(match_objs)
 
     # patient "delete_id" should have two associated matches in database
     assert database['matches'].find({'data.patient.id' : delete_id}).count() == 2
@@ -141,7 +141,7 @@ def test_delete_patient(database, demo_data_path, test_client, match_obs):
 
 
 
-def test_patient_matches(database, match_obs, test_client):
+def test_patient_matches(database, match_objs, test_client):
     """testing the endpoint that retrieves the matchings by patient ID"""
 
     app.db = database
@@ -152,7 +152,7 @@ def test_patient_matches(database, match_obs, test_client):
     # start from a database with no matches
     assert database['matches'].find().count() == 0
     # import mock matches into datababase
-    database['matches'].insert_many(match_obs)
+    database['matches'].insert_many(match_objs)
     # database now should have two matching objects
 
     # test endpoint to get matches by ID

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -265,15 +265,6 @@ def test_match_external(test_client, test_node, database, json_patients):
     assert database['matches'].find().count() == 1
 
 
-
-
-
-
-
-
-def test_notify_internal_match():
-    assert 0 == 0
-
 def unauth_headers():
     head = {
         'Content-Type': 'application/vnd.ga4gh.matchmaker.v1.0+json',

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -21,7 +21,6 @@ def test_add_patient(database, json_patients, test_client, test_node):
     response = app.test_client().post('patient/add', data=json.dumps(patient_data), headers=unauth_headers())
     assert response.status_code == 401
 
-
     # add an authorized client to database
     ok_token = test_client['auth_token']
 
@@ -265,6 +264,15 @@ def test_match_external(test_client, test_node, database, json_patients):
     # And a new match should be created in matches collection
     assert database['matches'].find().count() == 1
 
+
+
+
+
+
+
+
+def test_notify_internal_match():
+    assert 0 == 0
 
 def unauth_headers():
     head = {

--- a/tests/utils/test_notify.py
+++ b/tests/utils/test_notify.py
@@ -2,9 +2,9 @@
 import pymongo
 from patientMatcher.utils.notify import notify_match_external, notify_match_internal
 
-def test_notify_match_external(match_obs, mock_sender, mock_mail):
+def test_notify_match_external(match_objs, mock_sender, mock_mail):
 
-    match_obj = match_obs[0] #an external match object with results
+    match_obj = match_objs[0] #an external match object with results
 
     # When calling the function that sends external match notifications
     notify_match_external(match_obj, mock_sender, mock_mail)
@@ -16,9 +16,9 @@ def test_notify_match_external(match_obs, mock_sender, mock_mail):
     assert mock_mail._message
 
 
-def test_notify_match_internal(database, match_obs, mock_sender, mock_mail):
+def test_notify_match_internal(database, match_objs, mock_sender, mock_mail):
 
-    match_obj = match_obs[2] # an internal match object with results
+    match_obj = match_objs[2] # an internal match object with results
 
     # insert patient used as query in database:
     assert database['patients'].find().count() == 0

--- a/tests/utils/test_notify.py
+++ b/tests/utils/test_notify.py
@@ -5,6 +5,7 @@ from patientMatcher.utils.notify import notify_match_external, notify_match_inte
 def test_notify_match_external(match_objs, mock_sender, mock_mail):
 
     match_obj = match_objs[0] #an external match object with results
+    assert match_obj['match_type'] == 'external'
 
     # When calling the function that sends external match notifications
     notify_match_external(match_obj, mock_sender, mock_mail)
@@ -19,6 +20,7 @@ def test_notify_match_external(match_objs, mock_sender, mock_mail):
 def test_notify_match_internal(database, match_objs, mock_sender, mock_mail):
 
     match_obj = match_objs[2] # an internal match object with results
+    assert match_obj['match_type'] == 'internal'
 
     # insert patient used as query in database:
     assert database['patients'].find().count() == 0

--- a/tests/utils/test_notify.py
+++ b/tests/utils/test_notify.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import pymongo
+from patientMatcher.utils.notify import notify_match_external, notify_match_internal
+
+def test_notify_external_match(match_obs, mock_sender, mock_mail):
+    """Test external match notification"""
+
+    match_obj = match_obs[0] #an external match object with results
+
+    # When calling the function that sends external match notifications
+    notify_match_external(match_obj, mock_sender, mock_mail)
+
+    # make sure send method was called
+    assert mock_mail._send_was_called
+
+    # and that mail object message was set correctly
+    assert mock_mail._message
+
+
+def test_notify_external_match(database, match_obs, mock_sender, mock_mail):
+
+    match_obj = match_obs[2] # an internal match object with results
+
+    # insert patient used as query in database:
+    assert database['patients'].find().count() == 0
+    database['patients'].insert_one({ '_id' : 'external_patient_1'})
+    assert database['patients'].find().count() == 1
+
+    # When calling the function that sends internal match notifications
+    notify_match_internal(database, match_obj, mock_sender, mock_mail)
+
+    # make sure send method was called
+    assert mock_mail._send_was_called
+
+    # and that mail object message was set correctly
+    assert mock_mail._message

--- a/tests/utils/test_notify.py
+++ b/tests/utils/test_notify.py
@@ -2,8 +2,7 @@
 import pymongo
 from patientMatcher.utils.notify import notify_match_external, notify_match_internal
 
-def test_notify_external_match(match_obs, mock_sender, mock_mail):
-    """Test external match notification"""
+def test_notify_match_external(match_obs, mock_sender, mock_mail):
 
     match_obj = match_obs[0] #an external match object with results
 
@@ -17,7 +16,7 @@ def test_notify_external_match(match_obs, mock_sender, mock_mail):
     assert mock_mail._message
 
 
-def test_notify_external_match(database, match_obs, mock_sender, mock_mail):
+def test_notify_match_internal(database, match_obs, mock_sender, mock_mail):
 
     match_obj = match_obs[2] # an internal match object with results
 


### PR DESCRIPTION
Added the option to send email notification upon patient matching.
If email params in configuration file are valid an email notification is sent in the following situations:

- A patient is added to the database and the add request triggers a search on external nodes producing at least one result (/patient/add endpoint).
 - An external search is actively performed on connected nodes and returns at least one result (/match/external/<patient_id> endpoint).
 - The server is interrogated by an external node and returns at least one result match (/match endpoint). In this case a match notification is sent to each contact of the result matches.
 - An internal search is submitted to the server using a patient from the database (/match endpoint) and this search returns at least one match. In this case contact users of all patients involved will be notified (contact from query patient and contacts from the result patients).

With tests!