### PR TITLE
flattened out the matches result list and renamed results to matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Table of Contents:
     - [ Get the list of connected nodes (/nodes) ](#node_list)
     - [ Send a match request to server (/match) ](#match)
     - [ Send a match request to external nodes (/match/external/<patient_id>) ](#match_external)
-    - [ Show all matches for a given patient (/patient/matches/<patient_id>) ](#patient_matches)
+    - [ Show all matches for a given patient (/matches/<patient_id>) ](#patient_matches)
 6. [ Patient matching algorithm ](#matching_algorithm)
     - [ Genotyping matching algorithm ](#geno_matching)
     - [ Phenotyping matching algorithm ](#pheno_matching)
@@ -239,7 +239,7 @@ Read [here](#node_list) how to get a list with the ID of the connected nodes.
 &nbsp;&nbsp;
 
 <a name="patient_matches"></a>
-- **/patient/matches/<patient_id>**.
+- **/matches/<patient_id>**.
 &nbsp;Return all matches (internal and external) with positive results for a patient specified by an ID. Example:
 ```bash
 curl -X GET \

--- a/patientMatcher/match/handler.py
+++ b/patientMatcher/match/handler.py
@@ -185,6 +185,7 @@ def external_matcher(database, patient, node=None):
             results = json_response['results']
             if len(results):
                 external_match['has_matches'] = True
-                external_match['results'].append(results)
+                for result in results:
+                    external_match['results'].append(result)
 
     return external_match

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -104,6 +104,7 @@ def nodes():
 @blueprint.route('/matches/<patient_id>', methods=['GET'])
 def matches(patient_id):
     """Get all matches (external and internal) for a patient ID"""
+    LOG.info('getting all matches for patient {}'.format(patient_id))
     resp = None
     message = {}
     if not authorize(current_app.db, request): # not authorized, return a 401 status code
@@ -115,7 +116,7 @@ def matches(patient_id):
     # return only matches with at least one result
     results = patient_matches(current_app.db, patient_id)
     if results:
-        message = json.loads(json_util.dumps({'results' : results}))
+        message = json.loads(json_util.dumps({'matches' : results}))
     else:
         message['message'] = "Could not find any matches in database for patient ID {}".format(patient_id)
     resp = jsonify(message)

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -208,7 +208,7 @@ def test_patient_matches(database, match_objs, test_client):
     assert response.status_code == 200
     data = json.loads(response.data)
     # and there are matches in it
-    assert len(data['results']) == 2 # 2 matches returned because endpoint returns only matches with results
+    assert len(data['matches']) == 2 # 2 matches returned because endpoint returns only matches with results
 
     # Test that there are actually 3 matches by calling directly the function returning matches
     matches = patient_matches(database=database, patient_id='P0000079', type=None, with_results=False)


### PR DESCRIPTION
- Fixed /matches/patient_id endpoint description in readme
- /matches/patient_id returned a list of lists for external matches. It's returning just a list of patients now
- /matches/patient_id endpoint returns a list of matches objects called "matches", instead of "results" now
