### PR TITLE
Add metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Table of Contents:
 5. [ Server endpoints ](#endpoints)
     - [ Add patient to server (/patient/add) ](#add)
     - [ Delete patient from server (/patient/delete/<patient_id>) ](#delete)
-    - [ Get a list of patients on server (/patient/view) ](#view)
+    - [ Get server stats (/metrics) ](#metrics)
     - [ Get the list of connected nodes (/nodes) ](#node_list)
     - [ Send a match request to server (/match) ](#match)
     - [ Send a match request to external nodes (/match/external/<patient_id>) ](#match_external)
@@ -179,13 +179,15 @@ Matching results where the removed patient is instead listed among the matching 
 
 &nbsp;&nbsp;
 
-<a name="view"></a>
-- **/patient/view**.
-&nbsp;Use this endpoint to **get** a list of all patients in the database. Example:
+<a name="metrics"></a>
+- **/metrics**.
+&nbsp;Use this endpoint to **get** database metrics.<br>
+Stats which could be retrieved by a MME service are described [here](https://github.com/ga4gh/mme-apis/blob/master/metrics-api.md)<br>
+Example:
 ```bash
 curl -X GET \
   -H 'X-Auth-Token: custom_token' \
-  localhost:9020/patient/view
+  localhost:9020/metrics
 ```
 &nbsp;&nbsp;
 

--- a/instance/config.py
+++ b/instance/config.py
@@ -16,6 +16,10 @@ MAX_PHENO_SCORE = 0.5
 # Max results matches returned by server.
 MAX_RESULTS = 5
 
+# Disclaimer. This text is returned along with match results or server metrics
+DISCLAIMER = 'patientMatcher provides data in good faith as a research tool. patientMatcher makes no warranty nor assumes any legal responsibility for any purpose for which the data are used. Users should not attempt in any case to identify patients whose data is returned by the service. Users who intend to publish paper using this software should acknowldge patientMatcher and its developers (https://www.scilifelab.se/facilities/clinical-genomics-stockholm/).'
+
+
 # Email notification params.
 # Required only if you want to send match notifications to patients contacts
 #MAIL_SERVER = smtp_server

--- a/patientMatcher/match/handler.py
+++ b/patientMatcher/match/handler.py
@@ -55,22 +55,24 @@ def internal_matcher(database, patient_obj, max_pheno_score, max_geno_score, max
     """
     json_pat = json_patient(patient_obj)
     pheno_matches = []
+    pheno_m_keys = []
     geno_matches = []
+    geno_m_keys = []
     matches = []
 
     # phenotype score can be obtained if patient has an associated phenotype (HPO or OMIM terms)
-    if len(patient_obj['features']) or len(patient_obj['disorders']) > 0:
+    if patient_obj.get('features') or patient_obj.get('disorders'):
         LOG.info('Matching phenotypes against database patients..')
         pheno_matches = phenomatch(database, max_pheno_score, patient_obj.get('features',[]), patient_obj.get('disorders',[]))
+        pheno_m_keys = list(pheno_matches.keys())
 
     # genomic score can be obtained if patient has at least one genomic feature
     if len(patient_obj['genomicFeatures']) > 0:
         LOG.info('Matching variants/genes against database patients..')
         geno_matches = genomatch(database, patient_obj['genomicFeatures'], max_geno_score)
+        geno_m_keys = list(geno_matches.keys())
 
     # obtain unique list of all patient IDs returned by the 2 algorithms:
-    pheno_m_keys = list(pheno_matches.keys())
-    geno_m_keys = list(geno_matches.keys())
     unique_patients = list(set(pheno_m_keys + geno_m_keys))
 
     # create matching result objects with combined score from the 2 algorithms

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -27,7 +27,7 @@ def mme_patient(json_patient, compute_phenotypes=False):
         'label' : json_patient.get('label'),
         'sex' : json_patient.get('sex'),
         'contact' : json_patient['contact'],
-        'features' : json_patient['features'],
+        'features' : json_patient.get('features'),
         'genomicFeatures' : json_patient.get('genomicFeatures'),
         'disorders' : json_patient.get('disorders'),
         'species' : json_patient.get('species'),
@@ -35,7 +35,7 @@ def mme_patient(json_patient, compute_phenotypes=False):
         'inheritanceMode' : json_patient.get('inheritanceMode')
     }
 
-    if compute_phenotypes: # build Monarch phenotypes from patients' HPO terms
+    if mme_patient['features'] and compute_phenotypes: # build Monarch phenotypes from patients' HPO terms
         hpo_terms = features_to_hpo(json_patient['features'])
         computed_phenotypes = monarch_phenotypes(hpo_terms)
         mme_patient['monarch_phenotypes'] = computed_phenotypes

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -3,19 +3,19 @@ import logging
 from flask import jsonify
 from jsonschema import ValidationError
 from patientMatcher.constants import STATUS_CODES
+from patientMatcher.utils.stats import general_metrics
+from patientMatcher.utils.delete import delete_by_query
 from patientMatcher.utils.patient import patients
 from patientMatcher.parse.patient import json_patient, validate_api, mme_patient
 from patientMatcher.auth.auth import authorize
-from patientMatcher.utils.delete import delete_by_query
 from patientMatcher.match.handler import external_matcher
 
 LOG = logging.getLogger(__name__)
 
-def get_patients(database, patient_ids=None):
-    """return all patients in response to client"""
-    mme_patients = list(patients(database, patient_ids))
-    json_like_patients = [json_patient(mmep) for mmep in mme_patients]
-    return json_like_patients
+def metrics(database):
+    """return database metrics"""
+    db_metrics = general_metrics(database)
+    return db_metrics
 
 
 def get_nodes(database):

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -73,9 +73,9 @@ def metrics():
     """Get database metrics"""
     resp = None
     if authorize(current_app.db, request):
-        LOG.info('Authorized client requests all patients..')
+        LOG.info('Authorized client requests metrics..')
         results = controllers.metrics(database=current_app.db)
-        resp = jsonify(results)
+        resp = jsonify({'metrics' : results, 'disclaimer' : current_app.config.get('DISCLAIMER')})
         resp.status_code = 200
 
     else: # not authorized, return a 401 status code

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -68,13 +68,13 @@ def delete(patient_id):
     return resp
 
 
-@blueprint.route('/patient/view', methods=['GET'])
-def view():
-    """Get all patients in database"""
+@blueprint.route('/metrics', methods=['GET'])
+def metrics():
+    """Get database metrics"""
     resp = None
     if authorize(current_app.db, request):
         LOG.info('Authorized client requests all patients..')
-        results = controllers.get_patients(database=current_app.db)
+        results = controllers.metrics(database=current_app.db)
         resp = jsonify(results)
         resp.status_code = 200
 

--- a/patientMatcher/utils/stats.py
+++ b/patientMatcher/utils/stats.py
@@ -52,7 +52,7 @@ def general_metrics(db):
     for feat in feat_occurr:
         n_feat += feat.get('count')
 
-    # include in unique_gene_matches only matches axtively returned by the server (internal)
+    # include in unique_gene_matches only matches actively returned by the server (internal)
     match_type = {'match_type':'internal'}
     unique_gene_matches = db.matches.distinct('results.patients.patient.genomicFeatures.gene', match_type)
 

--- a/patientMatcher/utils/stats.py
+++ b/patientMatcher/utils/stats.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+import logging
+from datetime import date
+
+LOG = logging.getLogger(__name__)
+
+def general_metrics(db):
+    """Create an object with database metrics
+
+    Args:
+        db(pymongo.database.Database)
+
+    Returns:
+        metrics(dict): According to the MME API it should be a dictionary like this:
+            {
+                "metrics": {
+                    "numberOfCases": 0,
+                    "numberOfSubmitters": 0,
+                    "numberOfGenes": 0,
+                    "numberOfUniqueGenes": 0,
+                    "numberOfVariants": 0,
+                    "numberOfUniqueVariants": 0,
+                    "numberOfFeatures": 0,
+                    "numberOfUniqueFeatures": 0,
+                    "numberOfFeatureSets": 0, # endpoint is not returning this, at the moment
+                    "numberOfUniqueGenesMatched": 0,
+                    "numberOfCasesWithDiagnosis": 0,
+                    "numberOfRequestsReceived": 0,
+                    "numberOfPotentialMatchesSent": 0,
+                    "dateGenerated": "2017-08-24",
+
+                },
+                "disclaimer": "Disclaimer text...",
+                "terms": "Terms text..."
+            }
+    """
+    # get gene/occurrence for all genes in db
+    n_genes = 0
+    gene_occurrs = item_occurrence(db, 'genomicFeatures', 'genomicFeatures.gene', 'genomicFeatures.gene.id')
+    for gene_count in gene_occurrs:
+        n_genes += gene_count['count']
+
+    # get numberOfUniqueVariants/occurrence for all variants in db
+    variant_occurr = item_occurrence(db, 'genomicFeatures', 'genomicFeatures.variant', 'genomicFeatures.variant')
+    n_vars = 0
+    for var in variant_occurr:
+        n_vars += var.get('count')
+
+    # get feature/occurrence for all features in db
+    n_feat = 0
+    feat_occurr = item_occurrence(db, 'features', 'features.id')
+    for feat in feat_occurr:
+        n_feat += feat.get('count')
+
+    # include in unique_gene_matches only matches axtively returned by the server (internal)
+    match_type = {'match_type':'internal'}
+    unique_gene_matches = db.matches.distinct('results.patients.patient.genomicFeatures.gene', match_type)
+
+    metrics = {
+        'numberOfCases' : db.patients.count(),
+        'numberOfSubmitters' : len(db.patients.distinct('contact')),
+        'numberOfGenes' : n_genes,
+        'numberOfUniqueGenes': len(db.patients.distinct('genomicFeatures.gene')),
+        'numberOfVariants' : n_vars,
+        'numberOfUniqueVariants' : len(db.patients.distinct('genomicFeatures.variant')),
+        'numberOfFeatures' : n_feat,
+        'numberOfUniqueFeatures' : len(db.patients.distinct('features')),
+        'numberOfUniqueGenesMatched' : len(unique_gene_matches),
+        'numberOfCasesWithDiagnosis' : db.patients.find({'disorders': {'$exists': True, '$ne' : []} }).count(),
+        'numberOfRequestsReceived' : db.matches.find({'match_type':'internal'}).count(),
+        'numberOfPotentialMatchesSent' : db.matches.find({'match_type':'internal', 'has_matches': True}).count(),
+        'dateGenerated' : str(date.today())
+    }
+    return metrics
+
+
+def item_occurrence(db, unw1, group, unw2=None):
+    """Get a list of item/occurrence in patient collection
+
+    Args:
+        db(pymongo.database.Database)
+        unw1(string): first nested unwind item
+        group(string): item to group results by
+        unw2(string): second nested unwind item # none if nested level is missing
+
+    Returns:
+        item_occurr(list) example: [{'id':'item_obj', 'count': item_occurrence}, ..]
+    """
+    # create query pipeline
+    pipeline = [{"$unwind": ''.join(['$',unw1])}]
+    if unw2:
+        pipeline.append({"$unwind": ''.join(['$',unw2])})
+    pipeline.append({"$group": {"_id": ''.join(['$',group]), "count": {"$sum": 1}}})
+    item_occurr = list(db.patients.aggregate(pipeline))
+    return item_occurr

--- a/patientMatcher/utils/stats.py
+++ b/patientMatcher/utils/stats.py
@@ -57,14 +57,14 @@ def general_metrics(db):
     unique_gene_matches = db.matches.distinct('results.patients.patient.genomicFeatures.gene', match_type)
 
     metrics = {
-        'numberOfCases' : db.patients.count(),
-        'numberOfSubmitters' : len(db.patients.distinct('contact')),
+        'numberOfCases' : db.patients.find().count(),
+        'numberOfSubmitters' : len(db.patients.distinct('contact.href')),
         'numberOfGenes' : n_genes,
         'numberOfUniqueGenes': len(db.patients.distinct('genomicFeatures.gene')),
         'numberOfVariants' : n_vars,
         'numberOfUniqueVariants' : len(db.patients.distinct('genomicFeatures.variant')),
         'numberOfFeatures' : n_feat,
-        'numberOfUniqueFeatures' : len(db.patients.distinct('features')),
+        'numberOfUniqueFeatures' : len(db.patients.distinct('features.id')),
         'numberOfUniqueGenesMatched' : len(unique_gene_matches),
         'numberOfCasesWithDiagnosis' : db.patients.find({'disorders': {'$exists': True, '$ne' : []} }).count(),
         'numberOfRequestsReceived' : db.matches.find({'match_type':'internal'}).count(),

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -111,6 +111,8 @@ def test_metrics(database, test_client, demo_data_path, match_objs):
     assert metrics['numberOfGenes'] > metrics['numberOfUniqueGenes']
     assert metrics['numberOfVariants'] > metrics['numberOfUniqueVariants']
     assert metrics['numberOfFeatures'] > metrics['numberOfUniqueFeatures']
+    assert metrics['numberOfCasesWithDiagnosis'] >0
+    assert metrics['numberOfUniqueGenesMatched'] == 0 # no gene was provided in match_obj results
     assert metrics['numberOfRequestsReceived'] == 2 # Sent 2 requests
     assert metrics['numberOfPotentialMatchesSent'] == 1 # Just one has returned results
 


### PR DESCRIPTION
fix #67.
With this fix the server will be returning all the mandatory and optional metrics described here: https://github.com/ga4gh/mme-apis/blob/master/metrics-api.md except for one: **numberOfFeatureSets** (which is a bit of a pain to calculate and is optional anyway).

Updated tests and readme. Server is returning metrics instead of a list of patient (improved security!)