### PR TITLE
Introduce yourself in response

### DIFF
--- a/instance/config.py
+++ b/instance/config.py
@@ -19,6 +19,8 @@ MAX_RESULTS = 5
 # Disclaimer. This text is returned along with match results or server metrics
 DISCLAIMER = 'patientMatcher provides data in good faith as a research tool. patientMatcher makes no warranty nor assumes any legal responsibility for any purpose for which the data are used. Users should not attempt in any case to identify patients whose data is returned by the service. Users who intend to publish paper using this software should acknowldge patientMatcher and its developers (https://www.scilifelab.se/facilities/clinical-genomics-stockholm/).'
 
+# Server Host. Used when submitting queries and returning results
+MME_HOST = 'https://www.scilifelab.se/facilities/clinical-genomics-stockholm'
 
 # Email notification params.
 # Required only if you want to send match notifications to patients contacts

--- a/patientMatcher/auth/auth.py
+++ b/patientMatcher/auth/auth.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import requests
 
 import pymongo
 from flask import request
@@ -17,9 +18,9 @@ def authorize(database, request):
     Returns:
         authorized(bool): True or False
     """
-
     token = request.headers.get('X-Auth-Token')
     query = {'auth_token' : token}
-    authorized = database['clients'].find(query).count()
-    LOG.info('AUTH:{}'.format(bool(authorized)))
-    return authorized
+    authorized = database['clients'].find_one(query)
+    if bool(authorized):
+        LOG.info('Authorized client with id "{0}" submits a {1} request'.format(authorized['_id'], request.method))
+    return bool(authorized)

--- a/patientMatcher/cli/add.py
+++ b/patientMatcher/cli/add.py
@@ -70,7 +70,8 @@ def demodata(monarch_phenotypes):
     """Adds a set of 50 demo patients to database"""
     click.echo('Adding 50 test patients to database..')
     path_to_json_patients = os.path.abspath(os.path.join(current_app.root_path, 'resources', 'benchmark_patients.json'))
-    inserted_ids = load_demo(path_to_json_data=path_to_json_patients, mongo_db=current_app.db, compute_phenotypes=monarch_phenotypes)
+    inserted_ids = load_demo(path_to_json_data=path_to_json_patients, mongo_db=current_app.db,
+        host=current_app.config.get('MME_HOST') ,compute_phenotypes=monarch_phenotypes)
     click.echo('inserted {} patients into db'.format(len(inserted_ids)))
 
 

--- a/patientMatcher/match/handler.py
+++ b/patientMatcher/match/handler.py
@@ -124,11 +124,12 @@ def internal_matcher(database, patient_obj, max_pheno_score, max_geno_score, max
     return internal_match
 
 
-def external_matcher(database, patient, node=None):
+def external_matcher(database, host, patient, node=None):
     """Handles a query patient matching against all connected MME nodes
 
     Args:
         database(pymongo.database.Database)
+        host(str): Name of this server (MME_HOST in config file)
         patient(dict) : a MME patient entity
         node(str): id of the node to search in
 
@@ -165,7 +166,11 @@ def external_matcher(database, patient, node=None):
         token = node['auth_token']
         request_content_type = node['accepted_content']
 
-        headers = {'Content-Type': request_content_type, 'Accept': 'application/vnd.ga4gh.matchmaker.v1.0+json', "X-Auth-Token": token}
+        headers = {'Content-Type': request_content_type,
+            'Accept': 'application/vnd.ga4gh.matchmaker.v1.0+json',
+            "X-Auth-Token": token,
+            'Host' : host
+        }
         LOG.info('sending HTTP request to server: "{}"'.format(server_name))
         # send request and get response from server
         json_response = None

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -36,10 +36,10 @@ def patient(database, patient_id):
     return query_patient
 
 
-def match_external(database, query_patient, node=None):
+def match_external(database, host, query_patient, node=None):
     """Trigger an external patient matching for a given patient object"""
     # trigger the matching and save the matching id to variable
-    matching_obj = external_matcher(database, query_patient, node)
+    matching_obj = external_matcher(database, host, query_patient, node)
     # save matching object to database
 
     if matching_obj:

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -30,7 +30,8 @@ def add():
         return controllers.bad_request(formatted_patient)
 
     # else import patient to database
-    modified, inserted, matching_obj= backend_add_patient(mongo_db=current_app.db, patient=formatted_patient, match_external=True)
+    modified, inserted, matching_obj= backend_add_patient(mongo_db=current_app.db, patient=formatted_patient,
+        match_external=True, host=current_app.config.get('MME_HOST'))
     message = {}
 
     if modified:

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -155,7 +155,8 @@ def match_external(patient_id):
         resp.status_code = 200
         return resp
 
-    matching_obj = controllers.match_external(current_app.db, query_patient, node)
+    host = current_app.config.get('MME_HOST') # Introduce yourself in request
+    matching_obj = controllers.match_external(current_app.db, host, query_patient, node)
 
     if not matching_obj:
         message['message'] = "Could not find any other node connected to this MatchMaker server"
@@ -213,6 +214,7 @@ def match_internal():
     LOG.info('Found {} matching patients in database'.format(len(matches)))
 
     # return response with results
+    validate_response["disclaimer"] = current_app.config.get('DISCLAIMER')
     resp = jsonify(validate_response)
     resp.status_code = 200
     return resp

--- a/patientMatcher/utils/add.py
+++ b/patientMatcher/utils/add.py
@@ -11,13 +11,14 @@ from patientMatcher.match.handler import external_matcher
 
 LOG = logging.getLogger(__name__)
 
-def load_demo(path_to_json_data, mongo_db, compute_phenotypes=False):
+def load_demo(path_to_json_data, mongo_db, host, compute_phenotypes=False):
     """Inserts demo patient data into database
         Demo data consists of a set of 50 patients from this paper: http://onlinelibrary.wiley.com/doi/10.1002/humu.22850
 
         Args:
             path_to_demo_data(str): absolute path to json file containing the demo patients.
             mongo_db(pymongo.database.Database)
+            host(str): MME_HOST parameter in config file
             compute_phenotypes(bool) : if True most likely phenotypes will be computed using Monarch
 
         Returns:
@@ -38,7 +39,7 @@ def load_demo(path_to_json_data, mongo_db, compute_phenotypes=False):
                 #parse patient into format accepted by database
                 patient = mme_patient(json_patient, compute_phenotypes)
 
-                inserted_id = backend_add_patient(mongo_db, patient)[1]
+                inserted_id = backend_add_patient(mongo_db=mongo_db, host=host, patient=patient)[1]
                 if inserted_id:
                     inserted_ids.append(inserted_id)
                 pbar.update()
@@ -49,12 +50,13 @@ def load_demo(path_to_json_data, mongo_db, compute_phenotypes=False):
     return inserted_ids
 
 
-def backend_add_patient(mongo_db, patient, match_external=False):
+def backend_add_patient(mongo_db, host, patient, match_external=False):
     """
         Insert or update a patient in patientMatcher database
 
         Args:
             mongo_db(pymongo.database.Database)
+            host(str): MME_HOST parameter in config file
             patient(dict) : a MME patient entity
 
         Returns:
@@ -76,7 +78,7 @@ def backend_add_patient(mongo_db, patient, match_external=False):
     # and if there is a change in patients' collections (new patient or updated patient)
     # Matching is not triggered by inserting demo data into database
     if match_external and (modified or upserted):
-        matching_obj = external_matcher(mongo_db, patient)
+        matching_obj = external_matcher(mongo_db, host, patient)
         #save matching object to database
         mongo_db['matches'].insert_one(matching_obj)
 

--- a/tests/backend/test_backend_patient.py
+++ b/tests/backend/test_backend_patient.py
@@ -14,15 +14,15 @@ def test_load_demo_patients(demo_data_path, database):
     assert os.path.isfile(demo_data_path)
 
     # load demo data to mock database using function located under utils/load
-    inserted_ids = load_demo(demo_data_path, database)
+    inserted_ids = load_demo(demo_data_path, database, 'patientMatcher.host.se')
     assert len(inserted_ids) == 50 # 50 test cases should be loaded
 
     # make sure that trying to re-insert the same patients will not work
-    re_inserted_ids = load_demo(demo_data_path, database)
+    re_inserted_ids = load_demo(demo_data_path, database, 'patientMatcher.host.se')
     assert len(re_inserted_ids) == 0
 
     # try to call load_demo with an invalid patient file:
-    inserted_ids = load_demo('this_is_a_fakey_json_file.json', database)
+    inserted_ids = load_demo('this_is_a_fakey_json_file.json', database , 'patientMatcher.host.se')
     assert len(inserted_ids) == 0
 
 
@@ -36,7 +36,7 @@ def test_backend_remove_patient(json_patients, database):
     assert len(test_mme_patients) == 2
 
     # insert the 2 patients into the database
-    inserted_ids = [ backend_add_patient(mongo_db=database, patient=mme_patient, match_external=False) for mme_patient in test_mme_patients ]
+    inserted_ids = [ backend_add_patient(mongo_db=database, host='patientMatcher.host.se', patient=mme_patient, match_external=False) for mme_patient in test_mme_patients ]
     assert len(inserted_ids) == 2
 
     # make sure that inserted patients contain computed phenotypes from Monarch

--- a/tests/match/test_pheno_matching.py
+++ b/tests/match/test_pheno_matching.py
@@ -25,7 +25,7 @@ def test_phenotype_matching(json_patients, database, demo_data_path):
     """test the algorithm that compares the phenotype of a query patient against the database"""
 
     # insert demo patients into test database
-    inserted_ids = load_demo(demo_data_path, database)
+    inserted_ids = load_demo(demo_data_path, database, 'patientMatcher.host.se')
     assert len(inserted_ids) == 50 # 50 test cases should be loaded
 
     query_patient = json_patients[0]

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -91,7 +91,7 @@ def test_metrics(database, test_client, demo_data_path, match_objs):
     assert clients > 0
 
     # load demo data of 50 test patients
-    inserted_ids = load_demo(demo_data_path, database)
+    inserted_ids = load_demo(demo_data_path, database, app.config.get('MME_HOST'))
     assert len(inserted_ids) == 50 # 50 test cases should be loaded
 
     # load mock matches into database
@@ -155,7 +155,7 @@ def test_delete_patient(database, demo_data_path, test_client, match_objs):
 
     app.db = database
     # load demo data to mock database using function located under utils/load
-    inserted_ids = load_demo(demo_data_path, database)
+    inserted_ids = load_demo(demo_data_path, database, app.config.get('MME_HOST'))
     assert len(inserted_ids) == 50 # 50 test cases should be loaded
 
     # 50 cases present on patients collection
@@ -256,7 +256,7 @@ def test_match(json_patients, test_client, demo_data_path, database):
     query_patient = {'patient' : json_patients[0]}
 
     # load demo data in mock database
-    inserted_ids = load_demo(demo_data_path, database, False)
+    inserted_ids = load_demo(demo_data_path, database, app.config.get('MME_HOST'))
 
     # test the API response validator with non valid patient data:
     malformed_match_results = {'results': 'fakey_results'}


### PR DESCRIPTION
Send patientMatcher host in requests headers and return patientMatcher disclaimer along with match results in responses. 
Fix #66