### PR TITLE
Patient matcher dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,9 @@ COPY . /opt/patientMatcher
 WORKDIR /opt/patientMatcher
 
 RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate base && \
+    conda activate patientMatcher && \
     pip install -U pip setuptools && \
+    pip install -r requirements.txt -r requirements-dev.txt && \
     pip install -e .
 
 ENTRYPOINT [ "docker/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM mongo:4.0.7-xenial
 
 SHELL ["/bin/bash", "-c"]
 
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
 ENV PYTHON_VERSION 3.6
 ENV MONGO_PIDFILE /opt/patientMatcher/mongod.pid
 ENV MONGO_LOGPATH /opt/patientMatcher/mongod.log
@@ -42,4 +44,4 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     pip install -e .
 
 ENTRYPOINT [ "docker/entrypoint.sh" ]
-CMD [ "pmatcher", "run" ]
+CMD [ "pmatcher", "run", "-h", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM mongo:4.0.7-xenial
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bzip2 \
+    ca-certificates \
+    curl \
+    libglib2.0-0 \
+    libxext6 \
+    libsm6 \
+    libxrender1 \
+    wget \
+    vim && \
+    apt-get clean
+
+WORKDIR /root
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
+        /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+        rm ~/miniconda.sh && \
+        /opt/conda/bin/conda clean -tipsy && \
+        ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+        echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+        echo "conda activate base" >> ~/.bashrc && \
+        echo "echo 'in roots bashrc'" >> ~/.bashrc
+
+RUN mongod --fork --syslog && \
+    echo 'conn = new Mongo();db = conn.getDB("pmatcher");db.disableFreeMonitoring(); db.createUser({user: "pmUser", pwd: "pmPassword", roles:["dbOwner"]});' > setup_mongo.js && \
+    mongo setup_mongo.js
+
+COPY . /opt/patientMatcher
+
+WORKDIR /opt/patientMatcher
+
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate base && \
+    pip install -U pip setuptools && \
+    pip install -e .
+
+EXPOSE 5000
+
+CMD ["/bin/bash", "--rcfile", "/root/.bashrc", "-c", "pmatcher", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mongo:4.0.7-xenial
 
 SHELL ["/bin/bash", "-c"]
 
-ENV PYTHON_VERSION 3.7.1
+ENV PYTHON_VERSION 3.6
 ENV MONGO_PIDFILE /opt/patientMatcher/mongod.pid
 ENV MONGO_LOGPATH /opt/patientMatcher/mongod.log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate patientMatcher && \
     pip install -U pip setuptools && \
     pip install -r requirements.txt -r requirements-dev.txt && \
+    pip install pytest-cov coveralls && \
     pip install -e .
 
 ENTRYPOINT [ "docker/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Table of Contents:
 1. [ Prerequisites ](#prerequisites)
 2. [ Installation ](#installation)
+    - [ Using docker ](#installation-docker)
 3. [ Data types ](#data_types)
 4. [ Command line interface](#cli)
     - [ Adding demo data to server](#cli_add_demo)
@@ -62,6 +63,38 @@ To start the server run this command:
 pmatcher run -h custom_host -p custom_port
 ```
 Please note that the code is NOT guaranteed to be bug-free and it must be adapted to be used in production.
+
+<a name="installation-docker"></a>
+### Using Docker
+A simple Dockerfile has been included for testing purposes. It uses the sample `instance/config.py` and
+should not be used in production.
+
+#### Build the image
+From the repo directory:
+
+```bash
+# note: docker does not allow upper case in image tags
+$ docker build -t local/patientmatcher .
+```
+
+#### Running the image
+To run the image in the foreground use:
+```bash
+$ docker run -p 5000 --name patientMatcher local/patientmatcher
+```
+
+You can then `curl localhost:5000/...` to the appropriate resources from another terminal. The database is
+initialized with a test token (`test_token`) that can be used. e.g.,
+
+```bash
+$ curl -H 'x-auth-token: test_token' localhost:5000/metrics
+```
+
+To run with your own settings, mount an `instance` directory containing a `config.py`:
+
+```bash
+$ docker run -p 5000 -v /some/local/path/instance:/opt/patientMatcher/instance local/patientmatcher
+```
 
 <a name="data_types"></a>
 ## Data types

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,17 +1,23 @@
-#!/bin/bash
+#!/bin/bash -e
+
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [[ -z $(which python) ]]; then
     . /opt/conda/etc/profile.d/conda.sh
     conda activate patientMatcher
-    python -V
 fi
+
+# ugly grep, but lets user mount custom `instance/config.py` into image
+DB_USERNAME=$(grep '^DB_USERNAME =' $CURR_DIR/../instance/config.py | cut -f 3 -d' ' | tr -d \')
+DB_PASSWORD=$(grep '^DB_PASSWORD =' $CURR_DIR/../instance/config.py | cut -f 3 -d' ' | tr -d \')
+DB_NAME=$(grep '^DB_NAME =' $CURR_DIR/../instance/config.py | cut -f 3 -d' ' | tr -d \')
 
 SETUP_JS=/root/setup_mongo.js
 cat > $SETUP_JS << EOF
 conn = new Mongo();
-db = conn.getDB("pmatcher");
+db = conn.getDB("$DB_NAME");
 db.disableFreeMonitoring();
-db.createUser({user: "pmUser", pwd: "pmPassword", roles:["dbOwner"]});
+db.createUser({user: "$DB_USERNAME", pwd: "$DB_PASSWORD", roles:["dbOwner"]});
 EOF
 
 mongod --fork \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [[ -z $(which python) ]]; then
     . /opt/conda/etc/profile.d/conda.sh
-    conda activate base
+    conda activate patientMatcher
     python -V
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ -z $(which python) ]]; then
+    . /opt/conda/etc/profile.d/conda.sh
+    conda activate base
+    python -V
+fi
+
+SETUP_JS=/root/setup_mongo.js
+cat > $SETUP_JS << EOF
+conn = new Mongo();
+db = conn.getDB("pmatcher");
+db.disableFreeMonitoring();
+db.createUser({user: "pmUser", pwd: "pmPassword", roles:["dbOwner"]});
+EOF
+
+mongod --fork \
+    --pidfilepath $MONGO_PIDFILE \
+    --logpath $MONGO_LOGPATH --logappend
+mongo $SETUP_JS
+
+pmatcher add demodata
+pmatcher add client -id test_client -token test_token -url www.test-url.com
+
+exec "$@"

--- a/instance/config.py
+++ b/instance/config.py
@@ -5,8 +5,12 @@ DEBUG = True
 SECRET_KEY = 'MySuperSecretKey'
 
 # Database connection string
-DB_URI = "mongodb://pmUser:pmPassword@127.0.0.1:27017/pmatcher"
-DB_NAME = "pmatcher"
+DB_USERNAME = 'pmUser'
+DB_PASSWORD = 'pmPassword'
+DB_NAME = 'pmatcher'
+DB_HOST = '127.0.0.1'
+DB_PORT = 27017
+DB_URI = "mongodb://{}:{}@{}:{}/{}".format(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME)
 
 # Matching Algorithms scores
 # sum of MAX_GT_SCORE and MAX_PHENO_SCORE should be 1


### PR DESCRIPTION
I wanted to play with getting both implementations running on a single docker bridge on Friday, so I put this together.

Some options you may have opinions on:
* `Dockerfile`:
  * Set to use python 3.7.1, just since that was most recent. If you'd prefer a different version, can just change the `PYTHON_VERSION` var in Dockerfile
* `docker/entrypoint.sh`:
  * initial user creation based on values in `instance/config.py`, but they're hardcoded and not read directly from the file. Since they're throwaway creds, I figured that wasn't too big of a deal, but may be worth changing
  * adds initial demo data and token, but could have that be an extra step if a clean install is preferred