### PR TITLE
Unblock pymongo, pytest and mongomock dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Added
 - Codeowners document
 
+### Fixed
+- Avoid pymongo-related deprecated code
+- Unblock pytest and mongomock dependencies
+
 
 ## [2.1]
 

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -73,6 +73,7 @@ def check_request(database, request):
         return 401
 
     try: # make sure request has valid json data
+        LOG.error(str(request))
         request_json = request.get_json(force=True)
     except Exception as err:
         LOG.info("Json data in request is not valid:{}".format(err))

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -73,7 +73,6 @@ def check_request(database, request):
         return 401
 
     try: # make sure request has valid json data
-        LOG.error(str(request))
         request_json = request.get_json(force=True)
     except Exception as err:
         LOG.info("Json data in request is not valid:{}".format(err))

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -25,7 +25,6 @@ def add():
     """Add patient to database"""
 
     formatted_patient = controllers.check_request(current_app.db, request)
-    LOG.error(f"FORMATTED PATIENT--->{formatted_patient}")
     if isinstance(formatted_patient, int): # some error must have occurred during validation
         return controllers.bad_request(formatted_patient)
 

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -165,7 +165,7 @@ def match_external(patient_id):
     node = request.args.get('node')
 
     # if search should be performed on a specific node, make sure node is in database
-    if node and not current_app.db['nodes'].find({'_id':node}).count():
+    if node and current_app.db['nodes'].find_one({'_id':node}) is None:
         LOG.info('ERROR, theres no node with id "{}" in database'.format(request.args['node']))
         message['message'] = 'ERROR. Could not find any connected node with id {} in database'.format(request.args['node'])
         resp = jsonify(message)

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -25,6 +25,7 @@ def add():
     """Add patient to database"""
 
     formatted_patient = controllers.check_request(current_app.db, request)
+    LOG.error(f"FORMATTED PATIENT--->{formatted_patient}")
     if isinstance(formatted_patient, int): # some error must have occurred during validation
         return controllers.bad_request(formatted_patient)
 

--- a/patientMatcher/utils/add.py
+++ b/patientMatcher/utils/add.py
@@ -75,7 +75,6 @@ def backend_add_patient(mongo_db, patient, match_external=False):
     # and if there is a change in patients' collections (new patient or updated patient)
     # Matching is not triggered by inserting demo data into database
     if match_external and (modified or upserted):
-        LOG.error(f"modified:{modified}, upserted:{upserted}")
         matching_obj = external_matcher(mongo_db, patient)
         #save matching object to database
         mongo_db['matches'].insert_one(matching_obj)

--- a/patientMatcher/utils/add.py
+++ b/patientMatcher/utils/add.py
@@ -75,6 +75,7 @@ def backend_add_patient(mongo_db, patient, match_external=False):
     # and if there is a change in patients' collections (new patient or updated patient)
     # Matching is not triggered by inserting demo data into database
     if match_external and (modified or upserted):
+        LOG.error(f"modified:{modified}, upserted:{upserted}")
         matching_obj = external_matcher(mongo_db, patient)
         #save matching object to database
         mongo_db['matches'].insert_one(matching_obj)

--- a/patientMatcher/utils/stats.py
+++ b/patientMatcher/utils/stats.py
@@ -56,8 +56,12 @@ def general_metrics(db):
     match_type = {'match_type':'internal'}
     unique_gene_matches = db.matches.distinct('results.patients.patient.genomicFeatures.gene', match_type)
 
+    n_cases = sum(1 for i in db.patients.find())
+    n_cases_diagnosis = sum(1 for i in db.patients.find({'disorders': {'$exists': True, '$ne' : []} }))
+    n_requests = sum(1 for i in db.matches.find({'match_type':'internal'}))
+    n_positive_matches = sum(1 for i in db.matches.find({'match_type':'internal', 'has_matches': True}))
     metrics = {
-        'numberOfCases' : db.patients.find().count(),
+        'numberOfCases' : n_cases,
         'numberOfSubmitters' : len(db.patients.distinct('contact.href')),
         'numberOfGenes' : n_genes,
         'numberOfUniqueGenes': len(db.patients.distinct('genomicFeatures.gene')),
@@ -66,9 +70,9 @@ def general_metrics(db):
         'numberOfFeatures' : n_feat,
         'numberOfUniqueFeatures' : len(db.patients.distinct('features.id')),
         'numberOfUniqueGenesMatched' : len(unique_gene_matches),
-        'numberOfCasesWithDiagnosis' : db.patients.find({'disorders': {'$exists': True, '$ne' : []} }).count(),
-        'numberOfRequestsReceived' : db.matches.find({'match_type':'internal'}).count(),
-        'numberOfPotentialMatchesSent' : db.matches.find({'match_type':'internal', 'has_matches': True}).count(),
+        'numberOfCasesWithDiagnosis' : n_cases_diagnosis,
+        'numberOfRequestsReceived' : n_requests,
+        'numberOfPotentialMatchesSent' : n_positive_matches,
         'dateGenerated' : str(date.today())
     }
     return metrics

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,10 @@
 # testing:
 click
-pytest==4.4.1
-mongomock<=3.12
+pytest
+mongomock
 pytest-cov
 coveralls
 
 # server-related stuff
 requests
 Flask-Mail
-
-# database connection
-pymongo<3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 ## server
 Flask
 Flask-Mail
-Flask-Negotiate
+flask-negotiate
 requests
 jsonschema
+
 
 ## database connection
 pymongo

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 jsonschema
 
 ## database connection
-pymongo<3.7
+pymongo
 
 ##backend
 enlighten

--- a/tests/backend/test_backend_patient.py
+++ b/tests/backend/test_backend_patient.py
@@ -47,10 +47,10 @@ def test_backend_remove_patient(gpx4_patients, database):
     remove_query = {'_id' : 'P0001058'}
     deleted = delete_by_query(remove_query, database, 'patients')
     db_patients = database['patients'].find()
-    assert db_patients.count() == 1
+    assert len(list(db_patients)) == 1
 
     # test removing a patient by label:
     remove_query = {'label' : '350_2-test'}
     deleted = delete_by_query(remove_query, database, 'patients')
     db_patients = database['patients'].find()
-    assert db_patients.count() == 0
+    assert db_patients.find_one() is None

--- a/tests/backend/test_backend_patient.py
+++ b/tests/backend/test_backend_patient.py
@@ -52,5 +52,4 @@ def test_backend_remove_patient(gpx4_patients, database):
     # test removing a patient by label:
     remove_query = {'label' : '350_2-test'}
     deleted = delete_by_query(remove_query, database, 'patients')
-    db_patients = database['patients'].find()
-    assert db_patients.find_one() is None
+    assert database['patients'].find_one() is None

--- a/tests/backend/test_nodes.py
+++ b/tests/backend/test_nodes.py
@@ -8,15 +8,13 @@ def test_add_client(database, test_client):
     is_client = True
 
     # no clients should be present in demo database
-    nclients = database['clients'].find().count()
-    assert nclients == 0
+    assert database['clients'].find_one() is None
 
     inserted_id, collection = add_node(mongo_db=database, obj=test_client, is_client=is_client)
 
     assert inserted_id == test_client['_id']
     assert collection == 'clients'
-    nclients = database['clients'].find().count()
-    assert nclients == 1
+    assert database['clients'].find_one()
 
     # make sure that once a node is inserted it's not possible to add another node with the same id
     inserted_id, collection = add_node(mongo_db=database, obj=test_client, is_client=True)
@@ -29,15 +27,13 @@ def test_add_server(database, test_node):
     is_client = False
 
     # no server should be present in demo database
-    nservers = database['nodes'].find().count()
-    assert nservers == 0
+    assert database['nodes'].find_one() is None
 
     inserted_id, collection = add_node(mongo_db=database, obj=test_node, is_client=is_client)
 
     assert inserted_id == test_node['_id']
     assert collection == 'nodes'
-    nservers = database['nodes'].find().count()
-    assert nservers == 1
+    assert database['nodes'].find_one()
 
     # make sure that once a node is inserted it's not possible to add another node with the same id
     inserted_id, collection = add_node(mongo_db=database, obj=test_node, is_client=is_client)

--- a/tests/match/test_GT_matching.py
+++ b/tests/match/test_GT_matching.py
@@ -12,7 +12,8 @@ def test_genotype_matching(database, gpx4_patients):
         database['patients'].insert_one(mme_pat).inserted_id
 
     # 2 patients should be inserted
-    assert database['patients'].find({'genomicFeatures.gene.id': 'ENSG00000167468'}).count() == 2
+    results = database['patients'].find({'genomicFeatures.gene.id': 'ENSG00000167468'})
+    assert len(list(results)) == 2
 
     # test matching of a patient (with variants in genes) against the demo patients in database
     proband_patient = mme_patient(gpx4_patients[0], True)

--- a/tests/match/test_matching_handler.py
+++ b/tests/match/test_matching_handler.py
@@ -13,7 +13,8 @@ def test_internal_matching(database, gpx4_patients):
         database['patients'].insert_one(mme_pat).inserted_id
 
     # 2 patients should be inserted
-    assert database['patients'].find({'genomicFeatures.gene.id': 'ENSG00000167468'}).count() == 2
+    results = database['patients'].find({'genomicFeatures.gene.id': 'ENSG00000167468'})
+    assert len(list(results)) == 2
 
     # test matching of one of the 2 patients against both patients in database
     proband_patient = mme_patient(gpx4_patients[0], True)
@@ -35,7 +36,8 @@ def test_internal_matching_with_threshold(database, gpx4_patients):
         database['patients'].insert_one(mme_pat).inserted_id
 
     # 2 patients should be inserted
-    assert database['patients'].find({'genomicFeatures.gene.id': 'ENSG00000167468'}).count() == 2
+    results = database['patients'].find({'genomicFeatures.gene.id': 'ENSG00000167468'})
+    assert len(list(results)) == 2
 
     # test matching of one of the 2 patients against both patients in database
     proband_patient = mme_patient(gpx4_patients[0], True)
@@ -84,7 +86,8 @@ def test_save_async_response(database, test_node):
     """Testing the function that saves an async response object to database"""
 
     # Test database should not contain async responses
-    assert database['async_responses'].find().count() == 0
+    results = database['async_responses'].find()
+    assert len(results) == 0
 
     # Save an async response using the matching handler
     save_async_response(database=database, node_obj=test_node,

--- a/tests/match/test_matching_handler.py
+++ b/tests/match/test_matching_handler.py
@@ -87,7 +87,7 @@ def test_save_async_response(database, test_node):
 
     # Test database should not contain async responses
     results = database['async_responses'].find()
-    assert len(results) == 0
+    assert len(list(results)) == 0
 
     # Save an async response using the matching handler
     save_async_response(database=database, node_obj=test_node,

--- a/tests/match/test_pheno_matching.py
+++ b/tests/match/test_pheno_matching.py
@@ -51,7 +51,7 @@ def test_phenotype_matching(gpx4_patients, database):
     # insert 2 test patients into test database
     for patient in gpx4_patients:
         database['patients'].insert_one(patient)
-    database['patients'].find().count() == 2
+    assert len(list(database['patients'].find())) == 2
 
     query_patient = gpx4_patients[0]
     assert query_patient

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -207,7 +207,7 @@ def test_add_patient(mock_app, database, gpx4_patients, test_client, test_node):
     assert database['patients'].find_one({'label' : 'modified patient label'})
 
     # make sure that the POST request to add modify patient triggers the matching request to an external node again
-    results = database['matches'].find()
+    results = database.matches.find()
     assert len(list(results)) == 3
 
 

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -217,7 +217,7 @@ def test_add_patient(mock_app, test_client, gpx4_patients, test_node, database):
     assert result['genomicFeatures'][0]['gene']['_geneName'] == 'GPX4'
 
 
-def test_update_patient(mock_app, test_client, gpx4_patients, test_node, databas):
+def test_update_patient(mock_app, test_client, gpx4_patients, test_node, database):
     """Test updating a patient by sending a POST request to the add endpoint with valid data"""
 
     patient_data = gpx4_patients[1]

--- a/tests/utils/test_notify.py
+++ b/tests/utils/test_notify.py
@@ -24,9 +24,8 @@ def test_notify_match_internal(database, match_objs, mock_sender, mock_mail):
     assert match_obj['match_type'] == 'internal'
 
     # insert patient used as query in database:
-    assert database['patients'].find().count() == 0
-    database['patients'].insert_one({ '_id' : 'external_patient_1'})
-    assert database['patients'].find().count() == 1
+    assert database['patients'].find_one() is None
+    assert database['patients'].insert_one({ '_id' : 'external_patient_1'}).inserted_id
 
     # When calling the function that sends internal match notifications
     notify_complete = False # test notification of partial patient data by email


### PR DESCRIPTION
### This PR adds | fixes:
- Do not freeze pymongo, pytest and mongomock dependencies. Fix #142 and fix #143 

**How to prepare for test**:
- Install on clinical-db stage

### How to test:
- Save patient data from Scout interface, check that adding a new patient with one or more variants works.
- Send a request for stats from the command line (curl) to get the server stats to make sure the info endpoint still works

### Expected outcome:
- The above tests should work

### Review:
- [x] Tests executed by CR, Travis CI

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
