### PR TITLE
Raise an exception with informative error message when Ensembl REST API is needed but down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+###
+- Display error message and exit when Ensmbl Rest API is needed but offline
+
 ## [2.2] - 2020-10-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
-###
-- Display error message and exit when Ensmbl Rest API is needed but offline
+
+### Added
+- Display error message and raise exception when Ensembl Rest API is needed but offline
 
 ## [2.2] - 2020-10-19
 

--- a/patientMatcher/utils/ensembl_rest_client.py
+++ b/patientMatcher/utils/ensembl_rest_client.py
@@ -8,10 +8,11 @@ from urllib.request import Request, urlopen
 
 LOG = logging.getLogger(__name__)
 
-HEADERS = {'Content-type':'application/json'}
-RESTAPI_37 = 'https://grch37.rest.ensembl.org'
-RESTAPI_38 = 'https://rest.ensembl.org/'
-PING_ENDPOINT = 'info/ping'
+HEADERS = {"Content-type": "application/json"}
+RESTAPI_37 = "https://grch37.rest.ensembl.org"
+RESTAPI_38 = "https://rest.ensembl.org/"
+PING_ENDPOINT = "info/ping"
+
 
 class EnsemblRestApiClient:
     """A class handling requests and responses to and from the Ensembl REST APIs.
@@ -21,8 +22,8 @@ class EnsemblRestApiClient:
     doi:10.1093/bioinformatics/btu613
     """
 
-    def __init__(self, build='37'):
-        if build == '38':
+    def __init__(self, build="37"):
+        if build == "38":
             self.server = RESTAPI_38
         else:
             self.server = RESTAPI_37
@@ -36,16 +37,18 @@ class EnsemblRestApiClient:
         Returns:
             data(dict): dictionary from json response
         """
-        url = '/'.join([server, PING_ENDPOINT])
+        url = "/".join([server, PING_ENDPOINT])
         data = self.send_request(url)
         return data
 
-    def _except_on_invalid_response(self, resp):
+    def except_on_invalid_response(self, resp):
         """Checks if Ensembl service returned a valid response(status:200->OK), otherwise raise error with informative message"""
         # If service returned error
         if resp.status != 200:
-            # raise an exception with proper message
-            raise Exception(f"Ensembl Rest API server returned error {str(resp.status_code)} (it's probably down) and gene info could not be converted. Please try again later.")
+            # raise an exception with a proper message
+            raise Exception(
+                f"Ensembl Rest API server returned error {str(resp.status)} (it's probably down) and gene info could not be converted. Please try again later."
+            )
 
     def send_request(self, url):
         """Sends the actual request to the server and returns the response
@@ -60,14 +63,14 @@ class EnsemblRestApiClient:
         try:
             request = Request(url, headers=HEADERS)
             response = urlopen(request)
-            self._except_on_invalid_response(response)
+            self.except_on_invalid_response(response)
             content = response.read()
             if content:
                 data = json.loads(content)
         except HTTPError as e:
-            LOG.info('Request failed for url {0}: Error: {1}\n'.format(url, e))
+            LOG.info("Request failed for url {0}: Error: {1}\n".format(url, e))
             data = e
         except ValueError as e:
-            LOG.info('Request failed for url {0}: Error: {1}\n'.format(url, e))
+            LOG.info("Request failed for url {0}: Error: {1}\n".format(url, e))
             data = e
         return data

--- a/patientMatcher/utils/ensembl_rest_client.py
+++ b/patientMatcher/utils/ensembl_rest_client.py
@@ -40,6 +40,13 @@ class EnsemblRestApiClient:
         data = self.send_request(url)
         return data
 
+    def _abort_on_invalid_response(self, resp):
+        """Checks if Ensembl service returned a valid resposed. If not (service is down) abort with informative message"""
+
+        # If service returned error
+        if resp.status != 200:
+            LOG.error(f"Ensembl Rest API server returned error {str(resp.status_code)} (it's probably down) and gene info could not be converted. Please try again later.")
+            quit()
 
     def send_request(self, url):
         """Sends the actual request to the server and returns the response
@@ -54,6 +61,7 @@ class EnsemblRestApiClient:
         try:
             request = Request(url, headers=HEADERS)
             response = urlopen(request)
+            self._abort_on_invalid_response(response)
             content = response.read()
             if content:
                 data = json.loads(content)

--- a/patientMatcher/utils/ensembl_rest_client.py
+++ b/patientMatcher/utils/ensembl_rest_client.py
@@ -40,13 +40,12 @@ class EnsemblRestApiClient:
         data = self.send_request(url)
         return data
 
-    def _abort_on_invalid_response(self, resp):
-        """Checks if Ensembl service returned a valid resposed. If not (service is down) abort with informative message"""
-
+    def _except_on_invalid_response(self, resp):
+        """Checks if Ensembl service returned a valid response(status:200->OK), otherwise raise error with informative message"""
         # If service returned error
         if resp.status != 200:
-            LOG.error(f"Ensembl Rest API server returned error {str(resp.status_code)} (it's probably down) and gene info could not be converted. Please try again later.")
-            quit()
+            # raise an exception with proper message
+            raise Exception(f"Ensembl Rest API server returned error {str(resp.status_code)} (it's probably down) and gene info could not be converted. Please try again later.")
 
     def send_request(self, url):
         """Sends the actual request to the server and returns the response
@@ -61,7 +60,7 @@ class EnsemblRestApiClient:
         try:
             request = Request(url, headers=HEADERS)
             response = urlopen(request)
-            self._abort_on_invalid_response(response)
+            self._except_on_invalid_response(response)
             content = response.read()
             if content:
                 data = json.loads(content)

--- a/patientMatcher/utils/gene.py
+++ b/patientMatcher/utils/gene.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import logging
 import patientMatcher.utils.ensembl_rest_client as ensembl_client
 
 def entrez_to_symbol(entrez_id):
@@ -48,5 +47,5 @@ def ensembl_to_symbol(ensembl_id):
 
     client = ensembl_client.EnsemblRestApiClient()
     url = ''.join([client.server, '/lookup/id/', ensembl_id])
-    result = client.send_request(url)
-    return result.get('display_name', None)
+    results = client.send_request(url)
+    return results.get('display_name', None)

--- a/tests/utils/test_ensembl_rest_api.py
+++ b/tests/utils/test_ensembl_rest_api.py
@@ -1,38 +1,60 @@
 # -*- coding: UTF-8 -*-
+import pytest
 import tempfile
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 from patientMatcher.utils import ensembl_rest_client as ensembl_api
 
+
+def test_except_on_invalid_response():
+    """Test function that creates exception with message when response returned from Ensembl REST API has status code !=200"""
+
+    # GIVEN a response from Ensembl service with status != 200
+    client = ensembl_api.EnsemblRestApiClient()
+
+    class MockResponse:
+        def __init__(self):
+            self.status = 500
+
+    mockresp = MockResponse()
+
+    # Then it should trigger an exception
+    with pytest.raises(Exception):
+        result = client.except_on_invalid_response(mockresp)
+
+
 def test_ping_ensemble_37():
     """Test ping ensembl server containing human build 37"""
     client = ensembl_api.EnsemblRestApiClient()
     data = client.ping_server()
-    assert data == {'ping':1}
+    assert data == {"ping": 1}
+
 
 def test_ping_ensemble_38():
     """Test ping ensembl server containing human build 38"""
-    client = ensembl_api.EnsemblRestApiClient(build='38')
+    client = ensembl_api.EnsemblRestApiClient(build="38")
     data = client.ping_server()
-    assert data == {'ping':1}
+    assert data == {"ping": 1}
+
 
 def test_send_gene_request():
     """Test send request with correct params and endpoint"""
-    url = 'https://grch37.rest.ensembl.org/lookup/id/ENSG00000103591'
+    url = "https://grch37.rest.ensembl.org/lookup/id/ENSG00000103591"
     client = ensembl_api.EnsemblRestApiClient()
     data = client.send_request(url)
     # get info for the ensembl gene
-    assert data['display_name'] == 'AAGAB'
+    assert data["display_name"] == "AAGAB"
+
 
 def test_send_request_wrong_url():
     """Successful requests are tested by other tests in this file.
        This test will trigger errors instead.
     """
-    url = 'fakeyurl'
+    url = "fakeyurl"
     client = ensembl_api.EnsemblRestApiClient()
     data = client.send_request(url)
     assert type(data) == ValueError
 
-    url = 'https://grch37.rest.ensembl.org/fakeyurl'
+    url = "https://grch37.rest.ensembl.org/fakeyurl"
     data = client.send_request(url)
     assert type(data) == HTTPError


### PR DESCRIPTION
fix #147 

Ensembl REST API might be needed to upload or match patients, but sometimes it's down. The result is that patients are not uploaded but it's not clear why. This code raise an exception with an informative message:
`Ensembl Rest API server returned error <status code> (it's probably down) and gene info could not be converted. Please try again later`

### How to test:
- [ ] unittest

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
