### PR TITLE
Simplify Dockerfile and make it usable in production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.gitignore
+.travis.yml
+mkdocs.yml
+docs
+tests
+Dockerfile
+docker-compose.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.3] - 2020-10-28
+
+### Added
+- New Dockerfile and instructions to run on docker
+
+
 ## [2.2] - 2020-10-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="Chiara Rasi <chiara.rasi@scilifelab.se>"
 
 RUN apk update
 # Install required libs
-RUN apk --no-cache add git
+RUN apk --no-cache add git bash
 
 # Install patient_similarity from a fork @ClinicalGenomics
 # Original repo: https://github.com/buske/patient-similarity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,29 @@
-FROM mongo:4.0.7-xenial
+FROM python:3.8-alpine3.12
 
-SHELL ["/bin/bash", "-c"]
+LABEL version="1"
+LABEL about.license="MIT License (MIT)"
+LABEL software.version="2.3"
+LABEL about.home="https://github.com/Clinical-Genomics/patientMatcher"
+LABEL maintainer="Chiara Rasi <chiara.rasi@scilifelab.se>"
 
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
-ENV MONGO_PIDFILE /var/run/mongod.pid
-ENV MONGO_LOGPATH /var/log/mongodb/mongod.log
+RUN apk update
+# Install required libs
+RUN apk --no-cache add git
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    bzip2 \
-    ca-certificates \
-    curl \
-    libglib2.0-0 \
-    libxext6 \
-    libsm6 \
-    libxrender1 \
-    wget \
-    vim && \
-    apt-get clean
+# Install patient_similarity from a fork @ClinicalGenomics
+# Original repo: https://github.com/buske/patient-similarity
+RUN pip install git+https://github.com/Clinical-Genomics/patient-similarity
 
-WORKDIR /root
+WORKDIR /home/worker/app
+COPY . /home/worker/app
 
-ENV CONDA_VERSION 4.6.14
-COPY docker/conda_env.yml /root/conda_env.yml
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-        /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-        rm ~/miniconda.sh && \
-        ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-        echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-        echo "conda activate patientMatcher" >> ~/.bashrc && \
-        source /opt/conda/etc/profile.d/conda.sh && \
-        conda install -y conda=$CONDA_VERSION && \
-        conda env create -f /root/conda_env.yml && \
-        conda clean -tipsy
+# Install requirements
+RUN pip install -r requirements.txt
 
-COPY . /opt/patientMatcher
-WORKDIR /opt/patientMatcher
-RUN source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate patientMatcher && \
-    pip install git+https://github.com/Clinical-Genomics/patient-similarity && \
-    pip install -e .
+# Install the app
+RUN pip install -e .
 
-ENTRYPOINT [ "docker/entrypoint.sh" ]
-CMD [ "pmatcher", "run", "-h", "0.0.0.0", "-p", "9020" ]
+# Run commands as non-root user
+RUN adduser -D worker
+RUN chown worker:worker -R /home/worker
+USER worker

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 [![Build Status](https://travis-ci.com/Clinical-Genomics/patientMatcher.svg?branch=master)](https://travis-ci.com/Clinical-Genomics/patientMatcher) [![Coverage Status](https://coveralls.io/repos/github/Clinical-Genomics/patientMatcher/badge.svg?branch=master)](https://coveralls.io/github/Clinical-Genomics/patientMatcher?branch=master)
 
 Table of Contents:
-1. [ Prerequisites ](#prerequisites)
-2. [ Installation ](#installation)
-    - [ Using docker ](#installation-docker)
+1. [ Running the app using Docker ](#docker)
+2. [ Installing the app on a virtual environment with a running instance of MongoDB ](#installation)
 3. [ Data types ](#data_types)
 4. [ Command line interface](#cli)
     - [ Adding demo data to server](#cli_add_demo)
@@ -24,8 +23,35 @@ Table of Contents:
     - [ Phenotyping matching algorithm ](#pheno_matching)
 7. [ Enabling matching notifications ](#notify)
 
-<a name="prerequisites"></a>
-## Prerequisites
+<a name="docker"></a>
+## Running the app using Docker
+An example containing demo setup for the app is included in the docker-compose file. Note that this file is not intended for use in production and it's just to illustrate how the backend and frontend of the app could be connected to a mongodb instance store in an external docker image. Start the docker-compose demo using this command:
+
+```
+docker-compose up -d
+```
+The command will create 3 containers:
+- mongodb: starting a mongodb server with support for user authentication (--auth option)
+- pmatcher-cli: the a command-line app, which will connect to the server and populates it with demo data
+- pmatcher-web: a web server running on localhost and port 27017.
+
+The server will be running and accepting requests sent from outside the containers (another terminal or a web browser). Read further down to find out about requests and commands.
+
+To test a server response try to invoke the `metrics` endpoint with the following command:
+```
+curl localhost:5000/metrics
+```
+
+To stop the containers (and the server), run:
+```
+docker-compose down
+```
+
+
+<a name="installation"></a>
+## Installing the app on a virtual environment with a running instance of MongoDB
+
+### Prerequisites
 To use this server you'll need to have a working instance of **MongoDB**. from the mongo shell you can create a database and an authenticated user to handle connections using this syntax:
 
 ```bash
@@ -42,9 +68,6 @@ After setting up the restricted access to the server you'll just have to launch 
 ```bash
 mongod --auth --dbpath path_to_database_data
 ```
-
-<a name="installation"></a>
-## Installation
 The phenotype scoring algorithm of patientMatcher is dependent on [patient-similarity](https://github.com/buske/patient-similarity), which should be installed using this script:
 
 ```bash
@@ -71,37 +94,6 @@ pmatcher run -h custom_host -p custom_port
 ```
 Please note that the code is NOT guaranteed to be bug-free and it must be adapted to be used in production.
 
-<a name="installation-docker"></a>
-### Using Docker
-A simple Dockerfile has been included for testing purposes. It uses the sample `instance/config.py` and
-should not be used in production.
-
-#### Build the image
-From the repo directory:
-
-```bash
-# note: docker does not allow upper case in image tags
-$ docker build -t local/patientmatcher .
-```
-
-#### Running the image
-To run the image in the foreground use:
-```bash
-$ docker run -p 5000 --name patientMatcher local/patientmatcher
-```
-
-You can then `curl localhost:5000/...` to the appropriate resources from another terminal. The database is
-initialized with a test token (`test_token`) that can be used. e.g.,
-
-```bash
-$ curl localhost:5000/metrics
-```
-
-To run with your own settings, mount an `instance` directory containing a `config.py`:
-
-```bash
-$ docker run -p 5000 -v /some/local/path/instance:/opt/patientMatcher/instance local/patientmatcher
-```
 
 <a name="data_types"></a>
 ## Data types

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ To stop the containers (and the server), run:
 ```
 docker-compose down
 ```
+Make sure to remove the mongo container from the list of all available containers before running the command again.
+Commands:
+```
+docker ps -a
+docker rm <id of the vepo/mongo container>
+```
+
+
 
 
 <a name="installation"></a>

--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ docker ps -a
 docker rm <id of the vepo/mongo container>
 ```
 
-
-
-
 <a name="installation"></a>
 ## Installing the app on a virtual environment with a running instance of MongoDB
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ git clone https://github.com/Clinical-Genomics/patientMatcher.git
 
 Change directory to the cloned folder and from there install the software using the following command:
 ```bash
+pip install -r requirements.txt
 pip install -e .
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To add these patients to the database run the following command:
 pmatcher add demodata --ensembl_genes
 ```
 Please note that the list of benchmarking patients all gene ids are represented as HGNC gene symbols.
-The command above, with the `--ensembl_genes` option, will convert gene symbols to Ensembl ids, in accordance to the Ga4GH API: https://github.com/ga4gh/mme-apis/blob/master/search-api.md.
+The command above, with the `--ensembl_genes` option, will convert gene symbols to Ensembl ids, in accordance to the GA4GH API: https://github.com/ga4gh/mme-apis/blob/master/search-api.md.
 &nbsp;&nbsp;
 
 <a name="cli_remove_patient"></a>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,5 +41,5 @@ services:
     expose:
       - '5000'
     ports:
-      - '9020:5000'
+      - '5000:5000'
     command: bash -c 'pmatcher run --host 0.0.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 # usage:
-# docker-compose up
+# sudo docker-compose up
 services:
   mongodb:
     # Docker image for MongoDB which makes it easy to create:
@@ -8,15 +8,15 @@ services:
     # - database
     # - database user with password
     # when the container is first launched.
-    image: aashreys/mongo-auth
+    image: vepo/mongo
     container_name: mongo
     environment:
-      - AUTH=yes
-      - MONGODB_ADMIN_USER=root
-      - MONGODB_ADMIN_PASS=admin123
-      - MONGODB_APPLICATION_DATABASE=pmatcher
-      - MONGODB_APPLICATION_USER=pmUser
-      - MONGODB_APPLICATION_PASS=pmPassword
+      - AUTH=y
+      - ADMIN_USER=root
+      - ADMIN_PASS=admin123
+      - APPLICATION_DATABASE=pmatcher
+      - APPLICATION_USER=pmUser
+      - APPLICATION_PASS=pmPassword
     ports:
       - '27017:27017'
     expose:
@@ -41,5 +41,5 @@ services:
     expose:
       - '5000'
     ports:
-      - '5000:5000'
+      - '9020:5000'
     command: bash -c 'pmatcher run --host 0.0.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,31 +4,43 @@ version: '3'
 # sudo docker-compose up
 services:
   mongodb:
-    image: mvertes/alpine-mongo
-    container_name: mongodb
+    # Docker image for MongoDB which makes it easy to create:
+    # - admin
+    # - database
+    # - database user with password
+    # when the container is first launched.
+    image: aashreys/mongo-auth
+    container_name: mongo
+    environment:
+      - AUTH=yes
+      - MONGODB_ADMIN_USER=root
+      - MONGODB_ADMIN_PASS=admin123
+      - MONGODB_APPLICATION_DATABASE=pmatcher
+      - MONGODB_APPLICATION_USER=pmUser
+      - MONGODB_APPLICATION_PASS=pmPassword
     ports:
       - '27017:27017'
     expose:
       - '27017'
 
   pmatcher-cli:
+    image: northwestwitch/patientmatcher
     environment:
       MONGODB_HOST: mongodb
-    image: northwestwitch/patientmatcher
     container_name: pmatcher-cli
     links:
       - mongodb
     command: bash -c 'pmatcher add demodata --ensembl_genes'
 
   pmatcher-web:
+    image: northwestwitch/patientmatcher
     environment:
       MONGODB_HOST: mongodb
-    image: northwestwitch/patientmatcher
     container_name: pmatcher-web
     links:
       - mongodb
     expose:
       - '5000'
     ports:
-      - '9020:5000'
+      - '5000:5000'
     command: bash -c 'pmatcher run --host 0.0.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 # sudo docker-compose up
 services:
   mongodb:
-    # Docker image for MongoDB which makes it easy to create:
+    # Lightweight Docker image for MongoDB which makes it easy to create:
     # - admin
     # - database
     # - database user with password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+# usage:
+# sudo docker-compose build
+# sudo docker-compose up
+services:
+  mongodb:
+    image: mvertes/alpine-mongo
+    container_name: mongodb
+    ports:
+      - '27017:27017'
+    expose:
+      - '27017'
+
+  pmatcher-cli:
+    environment:
+      MONGODB_HOST: mongodb
+    image: northwestwitch/patientmatcher
+    container_name: pmatcher-cli
+    links:
+      - mongodb
+    command: bash -c 'pmatcher add demodata --ensembl_genes'
+
+  pmatcher-web:
+    environment:
+      MONGODB_HOST: mongodb
+    image: northwestwitch/patientmatcher
+    container_name: pmatcher-web
+    links:
+      - mongodb
+    expose:
+      - '5000'
+    ports:
+      - '9020:5000'
+    command: bash -c 'pmatcher run --host 0.0.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 # usage:
-# sudo docker-compose build
-# sudo docker-compose up
+# docker-compose up
 services:
   mongodb:
     # Docker image for MongoDB which makes it easy to create:

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -10,7 +10,6 @@ DB_PASSWORD = 'pmPassword'
 DB_NAME = 'pmatcher'
 DB_HOST = '127.0.0.1'
 DB_PORT = 27017
-DB_URI = "mongodb://{}:{}@{}:{}/{}".format(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME)
 
 # Matching Algorithms scores
 # sum of MAX_GT_SCORE and MAX_PHENO_SCORE should be 1

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -11,7 +11,6 @@ LOG = logging.getLogger(__name__)
 
 def create_app():
     app = None
-
     try:
         LOG.info('Configuring app from environment variable')
         app = Flask(__name__)
@@ -28,7 +27,15 @@ def create_app():
         app = Flask(__name__, instance_path=instance_path, instance_relative_config=True)
         app.config.from_pyfile('config.py')
 
-    client = MongoClient(app.config['DB_URI'])
+    db_username = app.config['DB_USERNAME']
+    db_password = app.config['DB_USERNAME']
+    # If app is runned from inside a container, override host port
+    db_host = os.getenv("MONGODB_HOST") or app.config['DB_HOST']
+    db_port = app.config['DB_PORT']
+    db_name = app.config['DB_NAME']
+    db_uri = f"mongodb://{db_username}:{db_password}@{db_host}:{db_port}/{db_name}"
+
+    client = MongoClient(db_uri)
     app.client = client
     app.db = client[app.config['DB_NAME']]
     LOG.info('database connection info:{}'.format(app.db))

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -28,7 +28,7 @@ def create_app():
         app.config.from_pyfile('config.py')
 
     db_username = app.config['DB_USERNAME']
-    db_password = app.config['DB_USERNAME']
+    db_password = app.config['DB_PASSWORD']
     # If app is runned from inside a container, override host port
     db_host = os.getenv("MONGODB_HOST") or app.config['DB_HOST']
     db_port = app.config['DB_PORT']

--- a/setup.py
+++ b/setup.py
@@ -22,33 +22,6 @@ LICENSE = 'MIT'
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-def parse_reqs(req_path='./requirements.txt'):
-    """Recursively parse requirements from nested pip files."""
-    install_requires = []
-    with io.open(os.path.join(here, 'requirements.txt'), encoding='utf-8') as handle:
-        # remove comments and empty lines
-        lines = (line.strip() for line in handle
-                 if line.strip() and not line.startswith('#'))
-
-        for line in lines:
-            # check for nested requirements files
-            if line.startswith('-r'):
-                # recursively call this function
-                install_requires += parse_reqs(req_path=line[3:])
-
-            else:
-                # add the line as a new requirement
-                install_requires.append(line)
-
-    return install_requires
-
-# What packages are required for this module to be executed?
-REQUIRED = parse_reqs()
-
-# The rest you shouldn't have to touch too much :)
-# ------------------------------------------------
-# Except, perhaps the License and Trove Classifiers!
-# If you do change the License, remember to change the Trove Classifier for that!
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.rst' is present in your MANIFEST.in file!
@@ -106,7 +79,6 @@ setup(
     download_url = '/'.join([URL,'tarball',version]),
     keywords = KEYWORDS,
     packages=find_packages(),
-    install_requires=REQUIRED,
     include_package_data=True,
     license=LICENSE,
     classifiers=[


### PR DESCRIPTION
### This PR adds | fixes:
- Create a minimal Dockerfile that installs the app and its requirements in a container
- Wrote a docker-compose file that illustrates how to set up 3 containers:
  - mongodb: starting a mongodb server with authentication (--auth option)
  - pmatcher-cli: the a command-line app, which will connect to the server and populates it with demo data
  - pmatcher-web: a web server running on localhost and port 27017.

fix #146
 
**How to prepare for test**:
- The image is pushed to my Docker Hub (couldn't figure out how to push it to our organization yet)

### How to test:
- [x] Stop any mongod instance already running on the local computer
- [x] Run `docker-compose up` in a terminal window
- [x] 50 patients should be saved in the database
- [x] Open another terminal window and send a request to the server, for instance the metrics (number of patients, number of genes, number of variants, etc):
`curl localhost:5000/metrics`

### Expected outcome:
- [x] The server should send a response with the stats of the database

### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
