### PR TITLE
Pull Docker images from clinicalgenomics Docker Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [] - 
+## [] -
+### Changed
+- Pulling Docker images in docker-compose from clinicalgenomics Docker Hub
 
 ### Added
 - Display error message and raise exception when Ensembl Rest API is needed but offline

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - '27017'
 
   pmatcher-cli:
-    image: northwestwitch/patientmatcher
+    image: clinicalgenomics/patientmatcher
     environment:
       MONGODB_HOST: mongodb
     container_name: pmatcher-cli
@@ -32,7 +32,7 @@ services:
     command: bash -c 'pmatcher add demodata --ensembl_genes'
 
   pmatcher-web:
-    image: northwestwitch/patientmatcher
+    image: clinicalgenomics/patientmatcher
     environment:
       MONGODB_HOST: mongodb
     container_name: pmatcher-web


### PR DESCRIPTION
Pull the repo Docker image from Clinical Genomics Docker Hub.

**How to prepare for test**:
- [x] Stop any mongodb instance already running locally
- [x] Run `docker-compose up -d`
- [x] Send request via web browser: `http://localhost:5000/metrics `
- [x] Stop the containers with the command `docker-compose down`

### Expected outcome:
- [x] 3 Containers are created without errors
- [x] The server should return a response

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
