### PR TITLE
Created Docker build and push action

### DIFF
--- a/.github/workflows/docker_build_n_publish.yml
+++ b/.github/workflows/docker_build_n_publish.yml
@@ -1,0 +1,22 @@
+name: Publish to Docker Hub
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+  docker-image-CI:
+   name: Docker Image CI
+   runs-on: ubuntu-latest
+   steps:
+    - name: Check out git repository
+      uses: actions/checkout@v2
+
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: clinicalgenomics/patientmatcher
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ github.event.release.tag_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - Display error message and raise exception when Ensembl Rest API is needed but offline
 - New Dockerfile and instructions to run on docker
+- Github action to build and push Docker image when a new software release is created
 
 
 ## [2.2] - 2020-10-19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM python:3.8-alpine3.12
 
-LABEL version="1"
+LABEL base_image="python:3.8-alpine3.12"
 LABEL about.license="MIT License (MIT)"
-LABEL software.version="2.3"
+LABEL about.tags="WGS,WES,Rare diseases,VCF,variants,phenotype,OMIM,HPO,variants"
 LABEL about.home="https://github.com/Clinical-Genomics/patientMatcher"
-LABEL maintainer="Chiara Rasi <chiara.rasi@scilifelab.se>"
 
 RUN apk update
 # Install required libs


### PR DESCRIPTION
Whenever a new version release is created, this actions builds the Docker image, tags it with 
- release version tag
- "latest"
- pushes the 2 tags to Docker Hub

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
