### PR TITLE
Simplify gene symbol conversions and don't crash when Ensembl REST API is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Display error message and raise exception when Ensembl Rest API is needed but offline
 - New Dockerfile and instructions to run on docker
 - Github action to build and push Docker image when a new software release is created
+- Try to match patients based on gene symbol (gene._geneName) if gene.id doesn't match
+
+### Fixed
+- Do not crash trying to convert genes when Ensembl REST API isn't available
 
 
 ## [2.2] - 2020-10-19

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -119,7 +119,7 @@ def format_genes(patient_obj):
 
 
 def _convert_gene(gene):
-    """Convert a gene ID to a gene symbol
+    """Convert provided gene id to Ensembl gene id and include eventual symbol
 
     Args:
         gene(str): can be either be:
@@ -136,12 +136,10 @@ def _convert_gene(gene):
         if gene.startswith("ENSG"):  # Ensembl gene ID
             symbol = ensembl_to_symbol(gene)
             return gene, symbol
-
         if gene.isdigit():  # Entrez id
             symbol = entrez_to_symbol(gene)
         else:  # non-Ensembl gene symbol
             symbol = gene
-
         if symbol:
             gene = symbol_to_ensembl(symbol) or gene
 

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -106,33 +106,51 @@ def format_genes(patient_obj):
     """
     formatted_features = []
     for feature in patient_obj.get("genomicFeatures", []):
-        symbol = None
         if "gene" in feature and feature["gene"].get("id"):
             gene = feature["gene"]["id"]
-            try:
-                if gene.isdigit() or gene.startswith("ENSG") is False:
-                    if gene.isdigit():  # Likely an entrez gene ID
-                        LOG.info("Converting entrez gene {} to symbol".format(gene))
-                        symbol = entrez_to_symbol(gene)
-                    else:  # It's a gene symbol
-                        symbol = gene
-                    if symbol:
-                        LOG.info("Converting gene symbol {} to Ensembl".format(symbol))
-                        ensembl_id = symbol_to_ensembl(symbol)
-                        if ensembl_id:
-                            feature["gene"]["id"] = ensembl_id
-                else:  # gene id is Ensembl id
-                    symbol = ensembl_to_symbol(gene)
-
-                if symbol:
-                    feature["gene"]["_geneName"] = symbol  # add non-standard but informative field
-            except Exception as ex:
-                LOG.error(f"An error occurred while using the Ensembl Rest API: {ex}")
-
+            gene_id, symbol = _convert_gene(gene)
+            if symbol:
+                feature["gene"]["_geneName"] = symbol  # add non-standard but informative field
+            feature["gene"]["id"] = gene_id
         formatted_features.append(feature)
 
     if formatted_features:
         patient_obj["genomicFeatures"] = formatted_features
+
+
+def _convert_gene(gene):
+    """Convert a gene ID to a gene symbol
+
+    Args:
+        gene(str): can be either be:
+            - a string representing an entrez id. example: "4556"
+            - a non-Ensembl gene symbol, example: "GPX4"
+            - An Ensembl gene ID, example: "ENSG00000167468"
+
+    Returns:
+        gene(str): An Ensembl gene
+        symbol(str): Ensembl gene ID. Example: "ENSG00000167468"
+    """
+    symbol = None
+    try:
+        if gene.startswith("ENSG"):  # Ensembl gene ID
+            symbol = ensembl_to_symbol(gene)
+            return gene, symbol
+
+        if gene.isdigit():  # Entrez id
+            symbol = entrez_to_symbol(gene)
+        else:  # non-Ensembl gene symbol
+            symbol = gene
+
+        if symbol:
+            gene = symbol_to_ensembl(symbol) or gene
+
+    except Exception as ex:
+        LOG.error(
+            f"An error occurred while converting gene format using the Ensembl Rest API: {ex}"
+        )
+
+    return gene, symbol
 
 
 def gtfeatures_to_genes(gtfeatures):

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -151,7 +151,7 @@ def _convert_gene(gene):
     return gene, symbol
 
 
-def gtfeatures_to_genes(gtfeatures):
+def gtfeatures_to_genes_symbols(gtfeatures):
     """Extracts all gene names from a list of genomic features
     Args:
         gtfeatures(list): a list of genomic features objects
@@ -160,11 +160,19 @@ def gtfeatures_to_genes(gtfeatures):
         gene_set(list): a list of unique gene names contained in the features
     """
     genes = []
+    symbols = []
     for feature in gtfeatures:
-        if "gene" in feature and feature["gene"].get("id"):  # collect non-null gene IDs
-            genes.append(feature["gene"]["id"])
+        if "gene" in feature:
+            gene = feature["gene"].get("id")
+            gene, symbol = _convert_gene(gene)
+            if gene:
+                genes.append(gene)
+            if symbol:
+                symbols.append(symbol)
+
     gene_set = list(set(genes))
-    return gene_set
+    symbol_set = list(set(symbols))
+    return gene_set, symbol_set
 
 
 def gtfeatures_to_variants(gtfeatures):

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -124,7 +124,7 @@ def _convert_gene(gene):
     Args:
         gene(str): can be either be:
             - a string representing an entrez id. example: "4556"
-            - a non-Ensembl gene symbol, example: "GPX4"
+            - a HGNC gene symbol, example: "GPX4"
             - An Ensembl gene ID, example: "ENSG00000167468"
 
     Returns:
@@ -138,7 +138,7 @@ def _convert_gene(gene):
             return gene, symbol
         if gene.isdigit():  # Entrez id
             symbol = entrez_to_symbol(gene)
-        else:  # non-Ensembl gene symbol
+        else:  # HGNC gene symbol
             symbol = gene
         if symbol:
             gene = symbol_to_ensembl(symbol) or gene

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -119,7 +119,7 @@ def format_genes(patient_obj):
 
 
 def _convert_gene(gene):
-    """Convert provided gene id to Ensembl gene id and include eventual symbol
+    """Convert provided gene id to Ensembl gene id return it with eventual HGNC gene symbol
 
     Args:
         gene(str): can be either be:
@@ -128,8 +128,8 @@ def _convert_gene(gene):
             - An Ensembl gene ID, example: "ENSG00000167468"
 
     Returns:
-        gene(str): An Ensembl gene
-        symbol(str): Ensembl gene ID. Example: "ENSG00000167468"
+        gene(str): An Ensembl gene ID, example: "ENSG00000167468"
+        symbol(str): HGNC gene symbol, example: "GPX4"
     """
     symbol = None
     try:

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -109,22 +109,25 @@ def format_genes(patient_obj):
         symbol = None
         if "gene" in feature and feature["gene"].get("id"):
             gene = feature["gene"]["id"]
-            if gene.isdigit() or gene.startswith("ENSG") is False:
-                if gene.isdigit():  # Likely an entrez gene ID
-                    LOG.info("Converting entrez gene {} to symbol".format(gene))
-                    symbol = entrez_to_symbol(gene)
-                else:  # It's a gene symbol
-                    symbol = gene
-                if symbol:
-                    LOG.info("Converting gene symbol {} to Ensembl".format(symbol))
-                    ensembl_id = symbol_to_ensembl(symbol)
-                    if ensembl_id:
-                        feature["gene"]["id"] = ensembl_id
-            else:  # gene id is Ensembl id
-                symbol = ensembl_to_symbol(gene)
+            try:
+                if gene.isdigit() or gene.startswith("ENSG") is False:
+                    if gene.isdigit():  # Likely an entrez gene ID
+                        LOG.info("Converting entrez gene {} to symbol".format(gene))
+                        symbol = entrez_to_symbol(gene)
+                    else:  # It's a gene symbol
+                        symbol = gene
+                    if symbol:
+                        LOG.info("Converting gene symbol {} to Ensembl".format(symbol))
+                        ensembl_id = symbol_to_ensembl(symbol)
+                        if ensembl_id:
+                            feature["gene"]["id"] = ensembl_id
+                else:  # gene id is Ensembl id
+                    symbol = ensembl_to_symbol(gene)
 
-            if symbol:
-                feature["gene"]["_geneName"] = symbol  # add non-standard but informative field
+                if symbol:
+                    feature["gene"]["_geneName"] = symbol  # add non-standard but informative field
+            except Exception as ex:
+                LOG.error(f"An error occurred while using the Ensembl Rest API: {ex}")
 
         formatted_features.append(feature)
 

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -16,21 +16,23 @@ def test_disorders_to_omim_no_omim():
 
 
 def test_mme_patient_gene_symbol(gpx4_patients, database):
-    # Test format a patient with gene symbol
+    # Test format a patient with HGNC gene symbol
 
     test_patient = gpx4_patients[0]
+    gene_name = test_patient["genomicFeatures"][0]["gene"]["id"]  # "GPX4"
     # Before conversion patient's gene id is a gene symbol
-    assert test_patient["genomicFeatures"][0]["gene"]["id"].startswith("ENSG") is False
+    assert gene_name.startswith("ENSG") is False
     mme_formatted_patient = mme_patient(test_patient, True)  # Convert gene symbol to Ensembl
     # After conversion formatted patient's gene id should be an Ensembl id
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["id"].startswith("ENSG")
+    assert mme_formatted_patient["genomicFeatures"][0]["gene"]["_geneName"] == gene_name
 
 
 def test_mme_patient_entrez_gene(entrez_gene_patient, database):
     # Test format a patient with entrez gene
-
     # Before conversion patient's gene id is an entrez gene ID
     assert entrez_gene_patient["genomicFeatures"][0]["gene"]["id"] == "3735"
     mme_formatted_patient = mme_patient(entrez_gene_patient, True)  # convert genes to Ensembl
     # After conversion formatted patient's gene id should be an Ensembl id
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["id"].startswith("ENSG")
+    assert mme_formatted_patient["genomicFeatures"][0]["gene"]["_geneName"]  # it's "KARS"


### PR DESCRIPTION
Genes in genomic features can be specified by:
- ensembl gene ID
- entrez gene ID
- gene symbol from the HGNC database

But the use of ensembl gene ID is strongly encouraged and will become mandatory in 2.0. See [here](https://github.com/ga4gh/mme-apis/blob/master/search-api.md#genomicfeatures) for more info.


We user Ensembl Rest API to convert non-canonical gene IDs (gene symbols like LAMA1, or Entrez gene IDs) to Ensembl gene IDs. But sometimes the service is down so the app crashes. 

This PR fixes that behavior this way: whenever the service is down we won't convert and leave the gene ID as it is provided by the request.

### How to test:
- 

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
