### PR TITLE
Coordinate liftover using Ensembl REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [] -
 ### Added
+- Code for performing coordinate liftover using Ensembl REST API
 ### Changed
 ### Fixed
 - removed unused docker folder

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,6 @@ services:
 
   pmatcher-cli:
     container_name: pmatcher-cli
-    build:
-      context: .
-      dockerfile: Dockerfile
     image: clinicalgenomics/patientmatcher
     environment:
       MONGODB_HOST: mongodb
@@ -41,9 +38,7 @@ services:
 
   pmatcher-web:
     container_name: pmatcher-web
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: clinicalgenomics/patientmatcher
     environment:
       MONGODB_HOST: mongodb
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'

--- a/patientMatcher/utils/variant.py
+++ b/patientMatcher/utils/variant.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import patientMatcher.utils.ensembl_rest_client as ensembl_client
 
 

--- a/patientMatcher/utils/variant.py
+++ b/patientMatcher/utils/variant.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import patientMatcher.utils.ensembl_rest_client as ensembl_client
+
+
+def liftover(build, chrom, start, end):
+    """Perform variant liftover using Ensembl REST API
+
+    Accepts:
+        build(str): genome build: GRCh37 or GRCh38
+        chrom(str): 1-22,X,Y,MT
+        start(int): start coordinate
+        stop(int): stop coordinate
+
+    Returns
+        mappings(list of dict): example: [{
+            "end": 1039365,
+            "seq_region_name": "X",
+            "coord_system": "chromosome",
+            "assembly": "GRCh38",
+            "start": 1039265,
+            "strand": 1
+          }]
+    """
+    assembly2 = "GRCh38"
+    if build == "GRCh38":
+        assembly2 = "GRCh37"
+
+    client = ensembl_client.EnsemblRestApiClient()
+    url = "/".join(
+        [
+            client.server,
+            "map/human",
+            build,
+            f"{chrom}:{start}..{end}",
+            f"{assembly2}?content-type=application/json",
+        ]
+    )
+    result = client.send_request(url)
+    if isinstance(result, dict):
+        return result.get("mappings")

--- a/patientMatcher/utils/variant.py
+++ b/patientMatcher/utils/variant.py
@@ -12,14 +12,8 @@ def liftover(build, chrom, start, end):
         stop(int): stop coordinate
 
     Returns
-        mappings(list of dict): example: [{
-            "end": 1039365,
-            "seq_region_name": "X",
-            "coord_system": "chromosome",
-            "assembly": "GRCh38",
-            "start": 1039265,
-            "strand": 1
-          }]
+        mappings(list of dict):
+            example: https://rest.ensembl.org/map/human/GRCh37/X:1000000..1000100:1/GRCh38?content-type=application/json
     """
     assembly2 = "GRCh38"
     if build == "GRCh38":

--- a/tests/utils/test_variant.py
+++ b/tests/utils/test_variant.py
@@ -42,3 +42,37 @@ def test_liftover_38_37():
 
     # And genome assembly should be GRCh37
     assert mappings[0]["mapped"]["assembly"] == "GRCh37"
+
+
+def test_liftover_MT_variant():
+    """Test liftover for a mitochondrial variant from GRCh37 to GRCh38"""
+
+    # GIVEN a mitochondrial variant
+    chromosome = "MT"
+    start = 7278
+    end = 7278
+
+    # THEN the service should return valid mappings
+    mappings = liftover("GRCh37", chromosome, start, end)
+
+    # Each mapping should have the expected output format
+    assert isinstance(mappings, list)
+    assert isinstance(mappings[0], dict)
+    for item in ["assembly", "seq_region_name", "start", "end"]:
+        assert mappings[0]["mapped"][item]
+
+    # And genome assembly should be GRCh38
+    assert mappings[0]["mapped"]["assembly"] == "GRCh38"
+
+
+def test_liftover_bad_request():
+    """Test variant liftover with non-valid request params"""
+
+    # WHEN sending a liftover request with non-standard chromosome (M instead of MT)
+    chromosome = "M"
+    start = 1000000
+    end = 1000000
+
+    # THEN the service should not return mappings
+    mappings = liftover("GRCh37", chromosome, start, end)
+    assert mappings is None

--- a/tests/utils/test_variant.py
+++ b/tests/utils/test_variant.py
@@ -1,0 +1,44 @@
+from patientMatcher.utils.variant import liftover
+
+
+def test_liftover_37_38():
+    """Test variant liftover from GRCh37 to GRCh38"""
+
+    # WHEN sending a liftover request with suitable coordinates in genome build 37
+    chromosome = "X"
+    start = 1000000
+    end = 1000000
+
+    # THEN the service should return valid mappings
+    mappings = liftover("GRCh37", chromosome, start, end)
+
+    # Each mapping should have the expected output format
+    assert isinstance(mappings, list)
+    assert isinstance(mappings[0], dict)
+    for item in ["assembly", "seq_region_name", "start", "end"]:
+        assert mappings[0]["mapped"][item]
+
+    # And genome assembly should be GRCh38
+    assert mappings[0]["mapped"]["assembly"] == "GRCh38"
+
+
+def test_liftover_38_37():
+    """Test variant liftover from GRCh38 to GRCh37"""
+
+    # WHEN sending a liftover request with suitable coordinates in genome build 38
+    chromosome = "X"
+    start = 1039265
+    end = 1039265
+
+    # THEN the service should return valid mappings
+    mappings = liftover("GRCh38", chromosome, start, end)
+
+    # Each mapping should have the expected output format
+    assert isinstance(mappings, list)
+    assert isinstance(mappings[0], dict)
+
+    for item in ["assembly", "seq_region_name", "start", "end"]:
+        assert mappings[0]["mapped"][item]
+
+    # And genome assembly should be GRCh37
+    assert mappings[0]["mapped"]["assembly"] == "GRCh37"

--- a/tests/utils/test_variant.py
+++ b/tests/utils/test_variant.py
@@ -70,8 +70,8 @@ def test_liftover_bad_request():
 
     # WHEN sending a liftover request with non-standard chromosome (M instead of MT)
     chromosome = "M"
-    start = 1000000
-    end = 1000000
+    start = 7278
+    end = 7278
 
     # THEN the service should not return mappings
     mappings = liftover("GRCh37", chromosome, start, end)


### PR DESCRIPTION
### This PR adds | fixes:
- Adds the code to perform coordinates liftover between GRCh37 and GRCh38

### How to test:
- Automatic tests

### Review:
- [ ] Code approved by
- [x] Tests executed by github actions (pytest)

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
