### PR TITLE
Use variant liftover when comparing patients variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [] -
 ### Added
 - Code for performing coordinate liftover using Ensembl REST API
+- Variant liftover when comparing genotype features
 ### Changed
+- Using coloredlogs for app logs
 ### Fixed
 - removed unused docker folder
 

--- a/patientMatcher/match/genotype_matcher.py
+++ b/patientMatcher/match/genotype_matcher.py
@@ -45,7 +45,7 @@ def match(database, gt_features, max_score):
         if symbols:
             query_fields.append({"genomicFeatures.gene._geneName": {"$in": symbols}})
 
-        # Obtain variants and the coresponding variants in the other genome build from the genotype features
+        # Obtain variants and the corresponding variants in the other genome build from the genotype features
         variants = gtfeatures_to_variants(gt_features)
         if variants:
             query_fields.append({"genomicFeatures.variant": {"$in": variants}})
@@ -119,7 +119,8 @@ def evaluate_GT_similarity(query_features, db_patient_features, max_feature_simi
                 "variant"
             )  # matching feature's variant. Not mandatory.
 
-            # variants are matching -> Assign max score
+            # if variants are matching or lifted query variant matches with matched patients variant
+            # ->assign max matching score
             if q_variant == m_variant or m_variant in lifted_q_variant:
                 matched_features[n_feature] = max_feature_similarity
 

--- a/patientMatcher/match/genotype_matcher.py
+++ b/patientMatcher/match/genotype_matcher.py
@@ -107,7 +107,7 @@ def evaluate_GT_similarity(query_features, db_patient_features, max_feature_simi
 
         # Do liftover for query variant in order to maximize perfect matching chances
         q_variant = feature.get("variant")  # query feature's variant. Not mandatory.
-        lifted_q_variant = lift_variant(q_variant)
+        lifted_q_variant = lift_variant(q_variant) if q_variant else []
 
         # loop over the database patient's features:
         for matching_feature in db_patient_features:

--- a/patientMatcher/match/phenotype_matcher.py
+++ b/patientMatcher/match/phenotype_matcher.py
@@ -129,11 +129,6 @@ def evaluate_pheno_similariy(
         omim_score = evaluate_subcategories(disorders, matching_omim_terms, max_omim_score)
 
     patient_similarity = hpo_score + omim_score
-    LOG.info(
-        "patient phenotype score: {0} (OMIM:{1}, HPO:{2})".format(
-            patient_similarity, omim_score, hpo_score
-        )
-    )
     return patient_similarity
 
 

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -226,6 +226,9 @@ def gtfeatures_to_variants(gtfeatures):
     variants = []
     for feature in gtfeatures:
         if "variant" in feature:
+            variant = feature["variant"]
+            if variant is None:
+                continue
             # Add variant to search terms
             variants.append(feature["variant"])
             # Add also corresponding variant in another genome build (GRCh38 if original variant was GRCh37, and the other way around)

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import json
+from copy import deepcopy
 from jsonschema import validate, RefResolver, FormatChecker
 from patientMatcher.utils.gene import symbol_to_ensembl, entrez_to_symbol, ensembl_to_symbol
+from patientMatcher.utils.variant import liftover
 from pkgutil import get_data
 import logging
 
@@ -175,6 +177,43 @@ def gtfeatures_to_genes_symbols(gtfeatures):
     return gene_set, symbol_set
 
 
+def lift_variant(variant):
+    """Perform a variant liftover using Ensebl REST API and return eventual variant in the other genome build
+
+    Args:
+        variant(dict): example:
+            {'assembly': 'GRCh38', 'referenceName': '12', 'start': 14641142, 'end': 14641142, 'referenceBases': 'C', 'alternateBases': 'T'}
+
+    Returns:
+        lifted_variants(list of dict): example:
+            [{'assembly': 'GRCh37', 'referenceName': '12', 'start': 14794076, 'end': 14794076, 'referenceBases': 'C', 'alternateBases': 'T'}]
+    """
+    lifted_vars = []
+    mappings = liftover(
+        variant.get("assembly"),
+        variant.get("referenceName"),
+        variant.get("start") + 1,  # coordinates are 0-based in Matchmaker
+        variant.get("end") + 1,
+    )
+
+    if mappings is None:
+        return lifted_vars
+
+    for res in mappings:
+        # Create a variant which is the copy of the original variant
+        lifted = deepcopy(variant)
+        mapped = res["mapped"]
+        # Modify coordinates of this variant according to mapping results
+        lifted["assembly"] = mapped["assembly"]
+        lifted["referenceName"] = mapped["seq_region_name"]
+        lifted["start"] = mapped["start"] - 1  # conver back to 0-based coordinates
+        lifted["end"] = mapped["end"] - 1
+
+        lifted_vars.append(lifted)
+
+    return lifted_vars
+
+
 def gtfeatures_to_variants(gtfeatures):
     """Extracts all variants from a list of genomic features
 
@@ -187,7 +226,14 @@ def gtfeatures_to_variants(gtfeatures):
     variants = []
     for feature in gtfeatures:
         if "variant" in feature:
+            # Add variant to search terms
             variants.append(feature["variant"])
+            # Add also coresponding variant in another genome build (GRCh38 if original variant was GRCh37, and the other way around)
+            lifted_variants = lift_variant(feature["variant"])
+            if not lifted_variants:
+                continue  # Variant could not be lifted to the other build
+            for lifted in lifted_variants:
+                variants.append(lifted)
 
     return variants
 

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -192,7 +192,7 @@ def lift_variant(variant):
     mappings = liftover(
         variant.get("assembly"),
         variant.get("referenceName"),
-        variant.get("start") + 1,  # coordinates are 0-based in Matchmaker
+        variant.get("start") + 1,  # coordinates are 0-based in MatchMaker
         variant.get("end") + 1,
     )
 
@@ -228,7 +228,7 @@ def gtfeatures_to_variants(gtfeatures):
         if "variant" in feature:
             # Add variant to search terms
             variants.append(feature["variant"])
-            # Add also coresponding variant in another genome build (GRCh38 if original variant was GRCh37, and the other way around)
+            # Add also corresponding variant in another genome build (GRCh38 if original variant was GRCh37, and the other way around)
             lifted_variants = lift_variant(feature["variant"])
             if not lifted_variants:
                 continue  # Variant could not be lifted to the other build

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import coloredlogs
 import os
 from pymongo import MongoClient
 import logging
@@ -6,7 +7,6 @@ from flask import Flask
 from flask_mail import Mail
 from . import views
 
-logging.basicConfig(level=logging.INFO)
 LOG = logging.getLogger(__name__)
 
 
@@ -27,6 +27,9 @@ def create_app():
 
         app = Flask(__name__, instance_path=instance_path, instance_relative_config=True)
         app.config.from_pyfile("config.py")
+
+    current_log_level = LOG.getEffectiveLevel()
+    coloredlogs.install(level="DEBUG" if app.debug else current_log_level)
 
     client = MongoClient(app.config["DB_URI"])
     app.client = client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 ## server
+coloredlogs
 Flask
-Flask-Mail
-flask-negotiate
+Flask - Mail
+flask - negotiate
 requests
 jsonschema
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 ## server
 coloredlogs
 Flask
-Flask - Mail
-flask - negotiate
+Flask-Mail
+flask-negotiate
 requests
 jsonschema
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,7 +204,34 @@ def patient_38():
                         "assembly": "GRCh38",
                         "referenceName": "12",
                         "start": 14641142,
-                        "end": 14641142,
+                        "end": 14641143,
+                        "referenceBases": "C",
+                        "alternateBases": "T",
+                    },
+                }
+            ],
+        }
+    }
+    return patient
+
+
+@pytest.fixture()
+def patient_37():
+    """A patient with a variant in genome assembly GRCh38"""
+
+    patient = {
+        "patient": {
+            "id": "patient_id",
+            "contact": {"name": "Contact Name", "href": "mailto:contact_name@mail.com"},
+            "features": [{"id": "HP:0009623"}],
+            "genomicFeatures": [
+                {
+                    "gene": {"id": "GUCY2C"},
+                    "variant": {
+                        "assembly": "GRCh37",
+                        "referenceName": "12",
+                        "start": 14794075,
+                        "end": 14794076,
                         "referenceBases": "C",
                         "alternateBases": "T",
                     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,33 +189,6 @@ def match_objs():
 
 
 @pytest.fixture()
-def patient_38():
-    """A patient with a variant in genome assembly GRCh38"""
-
-    patient = {
-        "patient": {
-            "id": "patient_id",
-            "contact": {"name": "Contact Name", "href": "mailto:contact_name@mail.com"},
-            "features": [{"id": "HP:0009623"}],
-            "genomicFeatures": [
-                {
-                    "gene": {"id": "GUCY2C"},
-                    "variant": {
-                        "assembly": "GRCh38",
-                        "referenceName": "12",
-                        "start": 14641142,
-                        "end": 14641143,
-                        "referenceBases": "C",
-                        "alternateBases": "T",
-                    },
-                }
-            ],
-        }
-    }
-    return patient
-
-
-@pytest.fixture()
 def patient_37():
     """A patient with a variant in genome assembly GRCh38"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,33 @@ def match_objs():
     return matches
 
 
+@pytest.fixture()
+def patient_38():
+    """A patient with a variant in genome assembly GRCh38"""
+
+    patient = {
+        "patient": {
+            "id": "patient_id",
+            "contact": {"name": "Contact Name", "href": "mailto:contact_name@mail.com"},
+            "features": [{"id": "HP:0009623"}],
+            "genomicFeatures": [
+                {
+                    "gene": {"id": "GUCY2C"},
+                    "variant": {
+                        "assembly": "GRCh38",
+                        "referenceName": "12",
+                        "start": 14641142,
+                        "end": 14641142,
+                        "referenceBases": "C",
+                        "alternateBases": "T",
+                    },
+                }
+            ],
+        }
+    }
+    return patient
+
+
 @pytest.fixture(scope="function")
 def gpx4_patients(json_patients):
     """Return all patients with variants in GPX4 gene"""

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from patientMatcher.parse.patient import features_to_hpo, disorders_to_omim, mme_patient
+from patientMatcher.parse.patient import (
+    features_to_hpo,
+    disorders_to_omim,
+    mme_patient,
+    gtfeatures_to_variants,
+)
 
 
 def test_features_to_hpo_no_features():
@@ -36,3 +41,22 @@ def test_mme_patient_entrez_gene(entrez_gene_patient, database):
     # After conversion formatted patient's gene id should be an Ensembl id
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["id"].startswith("ENSG")
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["_geneName"]  # it's "KARS"
+
+
+def test_gtfeatures_to_variants(patient_37):
+    """Test the function that parses variants dictionaries from patient's genotyle features"""
+
+    # GIVEN a patient containing 1 genomic feature (and one variant)
+    gt_features = patient_37["patient"]["genomicFeatures"]
+    assert len(gt_features) == 1
+
+    # WHEN gtfeatures_to_variants is used to extract variants from gt_features
+    variants = gtfeatures_to_variants(gt_features)
+
+    # THEN it should return 2 variants
+    assert len(variants) == 2
+
+    # One with genome build GRCh37
+    assert variants[0]["assembly"] == "GRCh37"
+    # And one with genome build GRCh38
+    assert variants[1]["assembly"] == "GRCh38"

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -44,7 +44,7 @@ def test_mme_patient_entrez_gene(entrez_gene_patient, database):
 
 
 def test_gtfeatures_to_variants(patient_37):
-    """Test the function that parses variants dictionaries from patient's genotyle features"""
+    """Test the function that parses variants dictionaries from patient's genomic features"""
 
     # GIVEN a patient containing 1 genomic feature (and one variant)
     gt_features = patient_37["patient"]["genomicFeatures"]

--- a/tests/utils/test_variant.py
+++ b/tests/utils/test_variant.py
@@ -70,8 +70,8 @@ def test_liftover_bad_request():
 
     # WHEN sending a liftover request with non-standard chromosome (M instead of MT)
     chromosome = "M"
-    start = 7278
-    end = 7278
+    start = 1000000
+    end = 1000000
 
     # THEN the service should not return mappings
     mappings = liftover("GRCh37", chromosome, start, end)

--- a/tests/utils/test_variant.py
+++ b/tests/utils/test_variant.py
@@ -70,8 +70,8 @@ def test_liftover_bad_request():
 
     # WHEN sending a liftover request with non-standard chromosome (M instead of MT)
     chromosome = "M"
-    start = 1000000
-    end = 1000000
+    start = 7278
+    end = 7278
 
     # THEN the service should not return mappings
     mappings = liftover("GRCh37", chromosome, start, end)


### PR DESCRIPTION
Compare patients variants taking into account that the matching patient might have exactly the same variant but in another genome build. Fix #161 

**How to prepare for test**:
- [x] Install the software locally
- [x] Load demo patients (they're all in build "GRCh37") with the command `pmatcher add demodata`
- [x] Create a test client:
```pmatcher add client -id dummynode -token custom_token -url whatevs.com```



### How to test:
- [x] run a query with a patient having exactly the same variant as one in database but in build "38":
```
curl -X POST \
  -H 'X-Auth-Token: custom_token' \
  -H 'Content-Type: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -H 'Accept: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -d '{"patient":{
    "id":"patient_id",
    "contact": {"name":"Contact Name", "href":"mailto:contact_name@mail.com"},
    "features":[{"id":"HP:0011344"}],
    "genomicFeatures":[{"gene":{"id":"GRIN2A"}, "variant":{"assembly":"GRCh38", "referenceName":"16", "start":9768996, "end":9768997,
    "referenceBases":"T", "alternateBases":"C"}}]
  }}' localhost:9020/match
```
- [x] run query first using the master branch
- [x] then launching the server from this branch

### Expected outcome:
- [x] The matching score () of one of the matching patients should be much higher when the server is running from this branch"""

### Review:
- [ ] Code approved by
- [x] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
