### PR TITLE
Fix liftover error for variants without end coordinate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 ### Changed
 ### Fixed
+- Liftover crashing when no end coordinate is not provided
 
 ## [2.4] - 2020-12-30
 ### Added

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -193,7 +193,7 @@ def lift_variant(variant):
         variant.get("assembly"),
         variant.get("referenceName"),
         variant.get("start") + 1,  # coordinates are 0-based in MatchMaker
-        variant.get("end") + 1,
+        variant.get("end") + 1 if variant.get("end") else variant.get("end"),
     )
 
     if mappings is None:
@@ -207,6 +207,8 @@ def lift_variant(variant):
         lifted["assembly"] = mapped["assembly"]
         lifted["referenceName"] = mapped["seq_region_name"]
         lifted["start"] = mapped["start"] - 1  # conver back to 0-based coordinates
+        if variant.get("end") is None:
+            continue
         lifted["end"] = mapped["end"] - 1
 
         lifted_vars.append(lifted)

--- a/patientMatcher/utils/variant.py
+++ b/patientMatcher/utils/variant.py
@@ -2,14 +2,14 @@
 import patientMatcher.utils.ensembl_rest_client as ensembl_client
 
 
-def liftover(build, chrom, start, end):
+def liftover(build, chrom, start, end=None):
     """Perform variant liftover using Ensembl REST API
 
     Accepts:
         build(str): genome build: GRCh37 or GRCh38
         chrom(str): 1-22,X,Y,MT
         start(int): start coordinate
-        stop(int): stop coordinate
+        stop(int): stop coordinate or None
 
     Returns
         mappings(list of dict):
@@ -25,7 +25,7 @@ def liftover(build, chrom, start, end):
             client.server,
             "map/human",
             build,
-            f"{chrom}:{start}..{end}",
+            f"{chrom}:{start}..{end or start}",  # End variant provided is not required
             f"{assembly2}?content-type=application/json",
         ]
     )


### PR DESCRIPTION
FIx #167 

### How to test:
Start demo app with demo data and run this request for a patient having a variant with no end coordinate:

```
curl -X POST \
  -H 'X-Auth-Token: custom_token' \
  -H 'Content-Type: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -H 'Accept: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -d '{"patient":{
    "id":"patient_id",
    "contact": {"name":"Contact Name", "href":"mailto:contact_name@mail.com"},
    "features":[{"id":"HP:0011344"}],
    "genomicFeatures":[{"gene":{"id":"GRIN2A"}, "variant":{"assembly":"GRCh38", "referenceName":"16", "start":9768996,
    "referenceBases":"T", "alternateBases":"C"}}]
  }}' localhost:9020/match
```


### Expected outcome:
- The same results observed in testing this PR #165 

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
