### PR TITLE
Notify admins via email when app crashes

### DIFF
--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -1,5 +1,5 @@
 name: Tests and coverage
-on: [pull_request]
+on: [push, pull_request]
 jobs:
   Pytest_Codecov:
     runs-on: ubuntu-18.04
@@ -25,6 +25,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [] -
 ### Added
+- Notify admins via email when app crashes
 ### Changed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Notify admins via email when app crashes
 ### Changed
 - Use codecov instead of coveralls in github actions
+- Send notification emails using TLS instead of SSL
 ### Fixed
 
 ## [2.4.1] - 2020-01-07

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -35,9 +35,13 @@ DISCLAIMER = "patientMatcher provides data in good faith as a research tool. pat
 # Required only if you want to send match notifications to patients contacts
 # MAIL_SERVER = mail_port
 # MAIL_PORT = email_port
+# MAIL_USE_TLS = True or False
 # MAIL_USE_SSL = True or False
 # MAIL_USERNAME = 'user_email@mail.se'
 # MAIL_PASSWORD = 'mail_password'
+
+# ADMINS will receive email notification is app crashes
+# ADMINS = []
 
 # Set NOTIFY_COMPLETE to False if you don't want to notify variants and phenotypes by email
 # This way only contact info and matching patients ID will be notified in email body

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -15,7 +15,7 @@ def configure_email_error_logging(app):
     """Setup logging of error/exceptions to email."""
 
     mail_handler = TlsSMTPHandler(
-        mailhost=app.config["MAIL_SERVER"],
+        mailhost=(app.config["MAIL_SERVER"], app.config["MAIL_PORT"]),
         fromaddr=app.config["MAIL_USERNAME"],
         toaddrs=app.config["ADMINS"],
         subject=f"{app.name} log error",
@@ -28,6 +28,7 @@ def configure_email_error_logging(app):
         )
     )
     app.logger.addHandler(mail_handler)
+    app.logger.exception(Exception("hello"))
 
 
 def create_app():

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -28,7 +28,6 @@ def configure_email_error_logging(app):
         )
     )
     app.logger.addHandler(mail_handler)
-    app.logger.exception(Exception("hello"))
 
 
 def create_app():

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -20,7 +20,7 @@ API_MIME_TYPE = "application/vnd.ga4gh.matchmaker.v1.0+json"
 
 @blueprint.route("/error")
 def raise_error():
-    raise Exception
+    raise InvalidUsage("This view is gone", status_code=410)
 
 
 @blueprint.route("/patient/add", methods=["POST"])

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -99,14 +99,11 @@ def heartbeat():
 @blueprint.route("/metrics", methods=["GET"])
 def metrics():
     """Get database metrics"""
-    """
     LOG.info("Receiving a requests for server metrics.")
     results = controllers.metrics(database=current_app.db)
     resp = jsonify({"metrics": results, "disclaimer": current_app.config.get("DISCLAIMER")})
     resp.status_code = 200
     return resp
-    """
-    raise Error("Raise a general error", status_code=410)
 
 
 @blueprint.route("/nodes", methods=["GET"])

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -18,6 +18,11 @@ blueprint = Blueprint("server", __name__)
 API_MIME_TYPE = "application/vnd.ga4gh.matchmaker.v1.0+json"
 
 
+@blueprint.route("/error")
+def raise_error():
+    raise Exception
+
+
 @blueprint.route("/patient/add", methods=["POST"])
 @consumes(API_MIME_TYPE, "application/json")
 @produces("application/json")

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -18,11 +18,6 @@ blueprint = Blueprint("server", __name__)
 API_MIME_TYPE = "application/vnd.ga4gh.matchmaker.v1.0+json"
 
 
-@blueprint.route("/error")
-def raise_error():
-    raise InvalidUsage("This view is gone", status_code=410)
-
-
 @blueprint.route("/patient/add", methods=["POST"])
 @consumes(API_MIME_TYPE, "application/json")
 @produces("application/json")
@@ -104,11 +99,14 @@ def heartbeat():
 @blueprint.route("/metrics", methods=["GET"])
 def metrics():
     """Get database metrics"""
+    """
     LOG.info("Receiving a requests for server metrics.")
     results = controllers.metrics(database=current_app.db)
     resp = jsonify({"metrics": results, "disclaimer": current_app.config.get("DISCLAIMER")})
     resp.status_code = 200
     return resp
+    """
+    raise Error("Raise a general error", status_code=410)
 
 
 @blueprint.route("/nodes", methods=["GET"])

--- a/patientMatcher/utils/notify.py
+++ b/patientMatcher/utils/notify.py
@@ -20,7 +20,6 @@ class TlsSMTPHandler(SMTPHandler):
                 from email.utils import formatdate
             except ImportError:
                 formatdate = self.date_time
-
             port = self.mailport
             if not port:
                 port = smtplib.SMTP_PORT
@@ -38,7 +37,6 @@ class TlsSMTPHandler(SMTPHandler):
                 smtp.starttls()  # For 'tls', add this line
                 smtp.ehlo()  # For 'tls', add this line
                 smtp.login(self.username, self.password)
-
             smtp.sendmail(self.fromaddr, self.toaddrs, msg)
             smtp.quit()
 

--- a/patientMatcher/utils/notify.py
+++ b/patientMatcher/utils/notify.py
@@ -1,8 +1,31 @@
 # -*- coding: utf-8 -*-
 import logging
+from logging.handlers import SMTPHandler
 from flask_mail import Message
 
 LOG = logging.getLogger(__name__)
+
+
+class SMTPErrorHandler(SMTPHandler):
+    """Handles the email notifications when the app crashes"""
+
+
+def notify_app_error(admin_email, app_admins_emails, mail, error):
+    """Send an email to server admin when the app crashes
+
+    Args:
+        admin_email(str): email of the server admin
+        app_admins_emails(list): email of app admins
+        mail(flask_mail.Mail): an email instance
+        error(str): log error text
+    """
+    sender = admin_email
+    recipients = app_admins_emails
+    email_subject = "MatchMaker Exchange app failed!"
+    email_body = None
+    LOG.error(
+        f"The following error occurred: {error}. Notifying admins {app_admins_emails} via email."
+    )
 
 
 def notify_match_internal(database, match_obj, admin_email, mail, notify_complete):

--- a/tests/server/test_create_app.py
+++ b/tests/server/test_create_app.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from patientMatcher.server import configure_email_error_logging
+from smtplib import SMTP
+from patientMatcher.utils.notify import TlsSMTPHandler
 
 
 def test_create_app(mock_app):
@@ -6,3 +9,32 @@ def test_create_app(mock_app):
 
     assert mock_app.client
     assert mock_app.db
+
+
+def test_error_log_email(mock_app):
+    """Test the app error logging via email"""
+
+    # GIVEN an app with an ADMIN and configured email error logging params
+    mail_host = "smtp.gmail.com"
+    mail_port = 587
+    server_email = "server_email"
+    server_pw = "server_pw"
+
+    mock_app.config["ADMINS"] = ["app_admin_email"]
+    mock_app.config["MAIL_SERVER"] = mail_host
+    mock_app.config["MAIL_PORT"] = mail_port
+    mock_app.config["MAIL_USERNAME"] = server_email
+    mock_app.config["MAIL_PASSWORD"] = server_pw
+
+    configure_email_error_logging(mock_app)
+
+    # Then a TlsSMTPHandler should be among the app loggers
+    handler = mock_app.logger.handlers[0]
+    assert type(handler) == TlsSMTPHandler
+    # And should contain the given settings
+    assert handler.mailhost == mail_host
+    assert handler.mailport == mail_port
+    assert handler.fromaddr == server_email
+    assert handler.password == server_pw
+    assert handler.toaddrs == mock_app.config["ADMINS"]
+    # assert handler.level

--- a/tests/server/test_create_app.py
+++ b/tests/server/test_create_app.py
@@ -30,7 +30,7 @@ def test_error_log_email(mock_app):
 
     # Then a TlsSMTPHandler should be among the app loggers
     handler = mock_app.logger.handlers[0]
-    assert type(handler) == TlsSMTPHandler
+    assert isinstance(handler, TlsSMTPHandler)
     # And should contain the given settings
     assert handler.mailhost == mail_host
     assert handler.mailport == mail_port

--- a/tests/server/test_create_app.py
+++ b/tests/server/test_create_app.py
@@ -37,4 +37,3 @@ def test_error_log_email(mock_app):
     assert handler.fromaddr == server_email
     assert handler.password == server_pw
     assert handler.toaddrs == mock_app.config["ADMINS"]
-    # assert handler.level


### PR DESCRIPTION
### This PR adds | fixes:
- fix #170 

**How to prepare for test**:
- [x] Create a PR/branch in servers repo where this [file](https://github.com/Clinical-Genomics/servers/blob/master/config/clinical-db.scilifelab.se/patientmatcher-stage.py) has an additional ADMINS param (a list) with at least one email address and.
- [x] Modify the same file by switching gmail email params from SSL to TLS:
```
MAIL_SERVER = 'smtp.gmail.com'
MAIL_PORT = 587
MAIL_USE_TLS = True
```
- [x] install on stage both this PR and the servers one

### How to test:
- [x] As soon as patientMatcher is installed and rebooted you (me) should receive an error email triggered by this line:
![image](https://user-images.githubusercontent.com/28093618/105017987-bd970880-5a44-11eb-9cc7-7c9b67a4c707.png)


### Expected outcome:
- [x] The admin specified in the servers config file should receive an email with the logged error

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
