### PR TITLE
Switch from coveralls to codecov in github actions

### DIFF
--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -1,7 +1,7 @@
 name: Tests and coverage
 on: [pull_request]
 jobs:
-  Pytest_Coveralls:
+  Pytest_Codecov:
     runs-on: ubuntu-18.04
     env:
       PMATCHER_CONFIG: ../instance/config.py
@@ -18,10 +18,14 @@ jobs:
         pip install git+https://github.com/Clinical-Genomics/patient-similarity
         pip install -e .
         pip install pytest
-        pip install coveralls
-    - name: Run pytest and coveralls
+        pip install pytest-cov
+    - name: Run pytest and codecov
       run: |
-        pytest --cov=patientMatcher tests/
-        coveralls
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        pytest --cov=./ --cov-report=xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        flags: unittests
+        env_vars: OS,PYTHON
+        name: codecov-umbrella
+        fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Added
 ### Changed
+- Use codecov instead of coveralls in github actions
 ### Fixed
 
 ## [2.4.1] - 2020-01-07


### PR DESCRIPTION
### This PR adds | fixes:
-  fix #174 

### How to test:
- All github actions tests should be successful

### Review:
- [ ] Tests executed by github actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
