### PR TITLE
Download phenotype annotation file from Monarch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Removed coveralls badge and added codecov badge
 ### Fixed
+- downloading phenotype_annotation.tab file from Monarch Initiative
 
 ## [2.5] - 2021-01-20
 ### Added

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -19,7 +19,7 @@ def resources(test):
     """Updates HPO terms and disease ontology from the web.
     Specifically collect files from:
     http://purl.obolibrary.org/obo/hp.obo
-    http://compbio.charite.de/jenkins/job/hpo.annotations/lastStableBuild/artifact/misc/phenotype_annotation.tab
+    https://raw.githubusercontent.com/monarch-initiative/hpo-survey-analysis/master/data/phenotype_annotation.tab
     """
     files = {}
     for key, item in PHENOTYPE_TERMS.items():

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -19,7 +19,7 @@ def resources(test):
     """Updates HPO terms and disease ontology from the web.
     Specifically collect files from:
     http://purl.obolibrary.org/obo/hp.obo
-    https://raw.githubusercontent.com/monarch-initiative/hpo-survey-analysis/master/data/phenotype_annotation.tab
+    https://ci.monarchinitiative.org/view/hpo/job/hpo.annotations/lastSuccessfulBuild/artifact/rare-diseases/misc/phenotype_annotation.tab
     """
     files = {}
     for key, item in PHENOTYPE_TERMS.items():

--- a/patientMatcher/constants/__init__.py
+++ b/patientMatcher/constants/__init__.py
@@ -17,7 +17,7 @@ PHENOTYPE_TERMS = {
         "resource_path": path_to_hpo_terms,
     },
     "hpo_annotations": {
-        "url": "http://compbio.charite.de/jenkins/job/hpo.annotations/lastStableBuild/artifact/misc/phenotype_annotation.tab",
+        "url": "https://raw.githubusercontent.com/monarch-initiative/hpo-survey-analysis/master/data/phenotype_annotation.tab",
         "resource_path": path_to_phenotype_annotations,
     },
 }

--- a/patientMatcher/constants/__init__.py
+++ b/patientMatcher/constants/__init__.py
@@ -17,7 +17,7 @@ PHENOTYPE_TERMS = {
         "resource_path": path_to_hpo_terms,
     },
     "hpo_annotations": {
-        "url": "https://raw.githubusercontent.com/monarch-initiative/hpo-survey-analysis/master/data/phenotype_annotation.tab",
+        "url": "https://ci.monarchinitiative.org/view/hpo/job/hpo.annotations/lastSuccessfulBuild/artifact/rare-diseases/misc/phenotype_annotation.tab",
         "resource_path": path_to_phenotype_annotations,
     },
 }


### PR DESCRIPTION
Modify link to a deprecated phenotype_annotation.tab to point to an up-to-date resource hosted by Monarch. 
Checked and some entries are pretty new, like Feb 2021, so it's a good temporary fix I think.

### This PR adds | fixes:
- Partial fix #181 

### How to test:
- [x] Execute the following command: `pmatcher update resources`

### Expected outcome:
- [x] A file named `phenotype_annotation.tab.txt` should be saved in patientMatcher/resources and should contain data

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
