### PR TITLE
Moved the Diseases handler to the app (decoupled from Patient-similarity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Changed
 - Removed coveralls badge and added codecov badge
 - Required downloading of hp.obo.txt and phenotype_annotation.tab.txt to run a non-test app
+- Integrate HPO parsing and handling into the software (decouple from Patient-similarity for HPO)
+- Integrate OMIM parsing and handling into the software (decouple from Patient-similarity for OMIM)
 ### Fixed
 - downloading phenotype_annotation.tab file from Monarch Initiative
 

--- a/patientMatcher/match/phenotype_matcher.py
+++ b/patientMatcher/match/phenotype_matcher.py
@@ -41,9 +41,13 @@ def match(database, max_score, features, disorders):
         # compare against all cases which also have features (HPO terms)
         query_fields.append({"features": {"$exists": True, "$ne": []}})
 
+        # Create the information-content functionality for the HPO
+        hpo = hpo_extension
+
+        diseases = diseases_extension
         hpoic = HPOIC(
-            hpo=hpo_extension,
-            diseases=diseases_extension,
+            hpo,
+            diseases,
             orphanet=None,
             patients=False,
             use_disease_prevalence=False,

--- a/patientMatcher/match/phenotype_matcher.py
+++ b/patientMatcher/match/phenotype_matcher.py
@@ -4,10 +4,11 @@
 import logging
 import os
 
-from patient_similarity import HPOIC, Diseases, Patient
+from patient_similarity import HPOIC, Patient
 from patient_similarity.__main__ import compare_patients
 from patientMatcher.parse.patient import disorders_to_omim, features_to_hpo
 from patientMatcher.resources import path_to_hpo_terms, path_to_phenotype_annotations
+from patientMatcher.server.extensions import diseases as diseases_extension
 from patientMatcher.server.extensions import hpo as hpo_extension
 
 LOG = logging.getLogger(__name__)
@@ -40,13 +41,9 @@ def match(database, max_score, features, disorders):
         # compare against all cases which also have features (HPO terms)
         query_fields.append({"features": {"$exists": True, "$ne": []}})
 
-        # Create the information-content functionality for the HPO
-        hpo = hpo_extension
-
-        diseases = Diseases(path_to_phenotype_annotations)
         hpoic = HPOIC(
-            hpo,
-            diseases,
+            hpo=hpo_extension,
+            diseases=diseases_extension,
             orphanet=None,
             patients=False,
             use_disease_prevalence=False,

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -78,6 +78,7 @@ def create_app():
         return
 
     extensions.hpo.init_app(app)
+    extensions.diseases.init_app(app)
 
     if app.config.get("MAIL_SERVER"):
         mail = Mail(app)

--- a/patientMatcher/server/extensions.py
+++ b/patientMatcher/server/extensions.py
@@ -1,3 +1,5 @@
+from patientMatcher.utils.disease import Diseases
 from patientMatcher.utils.hpo import HPO
 
 hpo = HPO()
+diseases = Diseases()

--- a/patientMatcher/utils/disease.py
+++ b/patientMatcher/utils/disease.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+import logging
+import re
+from collections import defaultdict
+
+from patientMatcher.resources import path_to_phenotype_annotations
+
+LOG = logging.getLogger(__name__)
+db_re = re.compile("([A-Z]+:\d+)")
+
+FREQUENCY_TERMS = {
+    "HP:0040280": 1.0,  # Obligate
+    "HP:0040281": (0.99 + 0.80) / 2.0,  # Very frequent
+    "HP:0040282": (0.79 + 0.30) / 2.0,  # Frequent
+    "HP:0040283": (0.05 + 0.29) / 2.0,  # Occasional
+    "HP:0040284": (0.01 + 0.04) / 2.0,  # Very rare
+    "HP:0040285": 0.0,  # Excluded
+}
+
+FREQUENCIES = {
+    "very rare": 0.01,
+    "rare": 0.05,
+    "occasional": 0.075,
+    "frequent": 0.33,
+    "typical": 0.5,
+    "variable": 0.5,
+    "common": 0.75,
+    "hallmark": 0.9,
+    "obligate": 1.0,
+}
+
+
+class Disease:
+    """An object representing a single disease"""
+
+    def __init__(self, db, id, phenotypes):
+        self.db = db
+        self.id = id
+        self.phenotype_freqs = phenotypes
+
+    def __str__(self):
+        return f"{self.db}:{self.id}"
+
+
+class Diseases:
+    """Create an object containing all diseases from the phenotype_annotations.tav.txt file
+    Resources included in this file: DECIPHER, OMIM, ORPHANET
+    """
+
+    def init_app(self, app):
+        """Initialize the diseases object when the app is launched"""
+        self.databases = ["DECIPHER", "OMIM", "ORPHA"]
+        self.diseases = {}
+        self._parse_diseases()
+
+    def _parse_disease_frequency(self, field):
+        """Parse disease frequency (col 8 in phenotype anno file)"""
+        if not field:
+            return None
+
+        if field.upper() in FREQUENCY_TERMS:
+            return FREQUENCY_TERMS[field]
+
+        field = field.lower()
+
+        if field in FREQUENCIES:
+            return FREQUENCIES[field]
+        elif field.endswith("%"):
+            field = field.replace("%", "")
+            if "-" in field:
+                # Average any frequency ranges
+                low, high = field.split("-")
+                freq = (float(low) + float(high)) / 2 / 100
+            else:
+                freq = float(field) / 100
+        else:
+            try:
+                num, denom = fraction_frequency_re.split(field)
+            except:
+                LOG.error("Error parsing frequency: {!r}".format(field))
+                freq = default
+            else:
+                freq = float(num) / float(denom)
+        return freq
+
+    def _parse_diseases(self):
+        """Parse diseases file, that is available under patientMatcher/resources"""
+        disease_phenotypes = defaultdict(dict)
+        with open(path_to_phenotype_annotations, encoding="utf-8") as disease_file:
+            for line in disease_file:
+                diseases = []
+                line = line.strip()
+                items = line.split("\t")
+
+                db = items[0]
+                if db not in self.databases:
+                    continue
+                diseases.append((items[0].strip(), items[1].strip()))  # diseases: [(OMIM, 102400)]
+
+                # Add alternative terms to list of diseases
+                alt_diseases = db_re.findall(items[5].strip())  # example: ['OMIM:147791']
+                for alt_disease in alt_diseases:
+                    alt_db = alt_disease.split(":")[0].strip()
+                    alt_db_id = int(alt_disease.split(":")[1].strip())
+                    if alt_db in ["MIM", "IM"]:
+                        alt_db = "OMIM"
+                    if alt_db not in self.databases:
+                        continue
+                    diseases.append((alt_db, alt_db_id))
+
+                # Add HPO terms and frequencies to disease terms
+                hpo_term = items[4].strip()
+                freq = self._parse_disease_frequency(items[8])
+                for disease in diseases:
+                    phenotypes = disease_phenotypes[disease]
+                    # Collect max annotated frequency
+                    if freq is not None and hpo_term in phenotypes:
+                        old_freq = phenotypes[hpo_term]
+                        if old_freq is None or old_freq < freq:
+                            phenotypes[hpo_term] = freq
+                        if old_freq != freq:
+                            pass
+                    else:
+                        phenotypes[hpo_term] = freq
+                    # phenotypes[hpo_term] = None  # Do not populate disease frequencies
+
+        for (db, id), phenotypes in disease_phenotypes.items():
+            disease = Disease(db, id, phenotypes)
+            self.diseases[(db, id)] = disease

--- a/patientMatcher/utils/disease.py
+++ b/patientMatcher/utils/disease.py
@@ -33,9 +33,9 @@ FREQUENCIES = {
 class Disease:
     """An object representing a single disease"""
 
-    def __init__(self, db, id, phenotypes):
+    def __init__(self, db, db_id, phenotypes):
         self.db = db
-        self.id = id
+        self.id = db_id
         self.phenotype_freqs = phenotypes
 
     def __str__(self):
@@ -65,7 +65,7 @@ class Diseases:
 
         if field in FREQUENCIES:
             return FREQUENCIES[field]
-        elif field.endswith("%"):
+        if field.endswith("%"):
             field = field.replace("%", "")
             if "-" in field:
                 # Average any frequency ranges
@@ -76,8 +76,8 @@ class Diseases:
         else:
             try:
                 num, denom = fraction_frequency_re.split(field)
-            except:
-                LOG.error("Error parsing frequency: {!r}".format(field))
+            except Exception as ex:
+                LOG.error(f"Error parsing frequency: {field} -> {ex}")
                 freq = default
             else:
                 freq = float(num) / float(denom)
@@ -124,6 +124,6 @@ class Diseases:
                         phenotypes[hpo_term] = freq
                     # phenotypes[hpo_term] = None  # Do not populate disease frequencies
 
-        for (db, id), phenotypes in disease_phenotypes.items():
-            disease = Disease(db, id, phenotypes)
-            self.diseases[(db, id)] = disease
+        for (db, db_id), phenotypes in disease_phenotypes.items():
+            disease = Disease(db, db_id, phenotypes)
+            self.diseases[(db, db_id)] = disease

--- a/patientMatcher/utils/disease.py
+++ b/patientMatcher/utils/disease.py
@@ -52,6 +52,7 @@ class Diseases:
         self.databases = ["DECIPHER", "OMIM", "ORPHA"]
         self.diseases = {}
         self._parse_diseases()
+        LOG.info(f"Parsed {len(self.diseases.keys())} disease/phenotypes from resource file")
 
     def _parse_disease_frequency(self, field):
         """Parse disease frequency (col 8 in phenotype anno file)"""

--- a/patientMatcher/utils/disease.py
+++ b/patientMatcher/utils/disease.py
@@ -77,7 +77,7 @@ class Diseases:
             try:
                 num, denom = fraction_frequency_re.split(field)
             except Exception as ex:
-                LOG.error(f"Error parsing frequency: {field} -> {ex}")
+                LOG.warning(f"Error parsing frequency: {field} -> {ex}")
                 freq = default
             else:
                 freq = float(num) / float(denom)

--- a/patientMatcher/utils/hpo.py
+++ b/patientMatcher/utils/hpo.py
@@ -71,13 +71,12 @@ class HPO(object):
     def init_app(self, app):
         """Initialize the HPO ontology when the app is launched."""
         self.hps = {}
-        self.parse_ontolology()
+        self._parse_ontolology()
         self.root = self.hps[ROOT]
 
-    def parse_ontolology(self):
+    def _parse_ontolology(self):
         """Parse HPO ontology file, that is available under patientMatcher/resources"""
         with open(path_to_hpo_terms, encoding="utf-8") as hpofile:
-            counter = 0
             hpo_lines = []  # A group of lines containing data for an HPO term
             for line in hpofile:
                 line = line.strip()
@@ -105,7 +104,7 @@ class HPO(object):
         for node in nodes:
             node.link(self.hps)
 
-        LOG.info(f"Parsed {len(nodes)} HP terms into HPO nodes from resource file")
+        LOG.info(f"Parsed {len(nodes)} HP0 terms into HPO nodes from resource file")
 
     def __getitem__(self, key):
         return self.hps[key]

--- a/patientMatcher/utils/hpo.py
+++ b/patientMatcher/utils/hpo.py
@@ -104,7 +104,7 @@ class HPO(object):
         for node in nodes:
             node.link(self.hps)
 
-        LOG.info(f"Parsed {len(nodes)} HP0 terms into HPO nodes from resource file")
+        LOG.info(f"Parsed {len(nodes)} HPO terms into HPO nodes from resource file")
 
     def __getitem__(self, key):
         return self.hps[key]

--- a/tests/server/test_extensions.py
+++ b/tests/server/test_extensions.py
@@ -13,8 +13,27 @@ def test_hpo(mock_app):
     assert type(hpo.hps) == dict
     # THEN the HPO should contain ontology root term
     assert hpo[root_term]
+    assert hpo[root_term].id == root_term
 
     # IT should also contain obsolete terms linked to non-obsolete terms
     assert hpo[obsolete_term].id != obsolete_term
     assert hpo[obsolete_term].parents
     assert hpo[obsolete_term]._parent_hps
+
+
+def test_diseases(mock_app):
+    """Test the extension handling disease terms"""
+
+    # GIVEN the hpo extension of an app
+    assert diseases
+
+    # THEN the hpo should countain disease terms in a dictionary
+    assert type(diseases.diseases) == dict
+
+    # GIVEN a specific term
+    test_db = "OMIM"
+    test_term = 201180
+    # Each dictionary key should contain the expected fields
+    assert diseases.diseases[(test_db, test_term)].db == test_db
+    assert diseases.diseases[(test_db, test_term)].id == test_term
+    assert diseases.diseases[(test_db, test_term)].phenotype_freqs

--- a/tests/server/test_extensions.py
+++ b/tests/server/test_extensions.py
@@ -1,0 +1,20 @@
+from patientMatcher.server.extensions import diseases, hpo
+
+
+def test_hpo(mock_app):
+    """Test the extension handling the HPO terms"""
+
+    root_term = "HP:0000001"
+    obsolete_term = "HP:0000057"
+
+    # GIVEN the hpo extension of an app
+    assert hpo
+    # THEN the hpo should countain HPO terms in a dictionary
+    assert type(hpo.hps) == dict
+    # THEN the HPO should contain ontology root term
+    assert hpo[root_term]
+
+    # IT should also contain obsolete terms linked to non-obsolete terms
+    assert hpo[obsolete_term].id != obsolete_term
+    assert hpo[obsolete_term].parents
+    assert hpo[obsolete_term]._parent_hps

--- a/tests/server/test_extensions.py
+++ b/tests/server/test_extensions.py
@@ -10,7 +10,7 @@ def test_hpo(mock_app):
     # GIVEN the hpo extension of an app
     assert hpo
     # THEN the hpo should countain HPO terms in a dictionary
-    assert type(hpo.hps) == dict
+    assert isinstance(hpo.hps, dict)
     # THEN the HPO should contain ontology root term
     assert hpo[root_term]
     assert hpo[root_term].id == root_term
@@ -28,7 +28,7 @@ def test_diseases(mock_app):
     assert diseases
 
     # THEN the hpo should countain disease terms in a dictionary
-    assert type(diseases.diseases) == dict
+    assert isinstance(diseases.diseases, dict)
 
     # GIVEN a specific term
     test_db = "OMIM"


### PR DESCRIPTION
### This PR adds | fixes:
- Moves the parsing and creating of the Diseases class to the app extensions (decoupling from patient-similarity)
- Initialize Diseases just once, when the app is launched, and not every time a phenotype matching occurs
- Use the in-house Diseases for phenotype matching (still handled by patient-similarity algorithm, for now)

**How to prepare for test**:
- [x] Should pass automatic tests
- [x] Install on stage:
`bash servers/resources/clinical-db.scilifelab.se/update-pmatcher-stage.sh decouple_diseases`

### How to test:
- [x] Try to run matches for a demo case (https://scout-stage.scilifelab.se/cust101/A1383)

### Expected outcome:
- [x] Make sure the matching returns results and the scores are the same as in master branch

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
