### PR TITLE
Introduce inclusive language check in repo

### DIFF
--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -1,0 +1,17 @@
+name: woke
+on: [pull_request]
+jobs:
+  linter_name:
+    name: runner / woke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: get-woke/woke-action-reviewdog@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-pr-review
+          # Change reporter level if you need.
+          # GitHub Status Check won't become failure with warning.
+          level: warning
+          fail-on-error: true

--- a/.github/workflows/woke.yaml
+++ b/.github/workflows/woke.yaml
@@ -10,7 +10,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
-          reporter: github-pr-review
+          reporter: github-pr-check
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with warning.
           level: warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Added
 - Email logging of errors howto in readme
+- Inclusive-language check using [woke](https://github.com/get-woke/woke) github action
 ### Changed
 - Removed coveralls badge and added codecov badge
 - Required downloading of hp.obo.txt and phenotype_annotation.tab.txt to run a non-test app


### PR DESCRIPTION
### This PR adds | fixes:
- Introduced a github action to warn for non-inclusive language content in this repo: check the woke page: https://github.com/get-woke/woke

**How to prepare for test**:
- Tests are executed via the github actions

### Expected outcome:
- [ ] Get warnings if non-sensitive expressions are found in this repo

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
