### PR TITLE
Update docker-compose ports for app and database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Required downloading of hp.obo.txt and phenotype_annotation.tab.txt to run a non-test app
 - Integrate HPO parsing and handling into the software (decouple from Patient-similarity for HPO)
 - Integrate OMIM parsing and handling into the software (decouple from Patient-similarity for OMIM)
+- Use app port 9020 instead of 5000 in docker-compose
+- Use MongoDB port 27013 instead of 27017 in docker-compose
 ### Fixed
 - downloading phenotype_annotation.tab file from Monarch Initiative
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,9 @@ services:
       - APPLICATION_USER=pmUser
       - APPLICATION_PASS=pmPassword
     ports:
-      - '27017:27017'
+      - '27013:27013'
     expose:
-      - '27017'
+      - '27013'
 
   pmatcher-cli:
     container_name: pmatcher-cli
@@ -46,11 +46,11 @@ services:
       - mongodb
     networks:
       - pmatcher-net
-    expose:
-      - '5000'
     ports:
-      - '5000:5000'
-    command: bash -c 'pmatcher run --host 0.0.0.0'
+      - '9020:9020'
+    expose:
+      - '9020'
+    command: bash -c 'pmatcher run --host 0.0.0.0 -p 9020'
 
 networks:
   pmatcher-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,9 @@ services:
       - APPLICATION_USER=pmUser
       - APPLICATION_PASS=pmPassword
     ports:
-      - '27013:27013'
+      - '27013:27017'
     expose:
-      - '27013'
+      - '27017'
 
   pmatcher-cli:
     container_name: pmatcher-cli


### PR DESCRIPTION
### This PR adds | fixes:
- fix #188 

### How to test:
- launch the demo app with the command 'docker-compose up'

### Expected outcome:
- [x] App port should now be 9020
- [x] Database port should now be 27013 (exposed port is still 27017)

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
