### PR TITLE
Modify connection Bridge address used in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Integrate OMIM parsing and handling into the software (decouple from Patient-similarity for OMIM)
 - Use app port 9020 instead of 5000 in docker-compose
 - Use MongoDB port 27013 instead of 27017 in docker-compose
+- Subnet address used in bridge of docker-compose file
 ### Fixed
 - downloading phenotype_annotation.tab file from Monarch Initiative
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,4 +58,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.21.0.0/24
+        - subnet: 172.24.0.0/24


### PR DESCRIPTION
### How to test:
- run docker-compose up and make sure it works

### Expected outcome:
- [x] works

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
