### PR TITLE
Fix document keys for demo data client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Demo client with token `DEMO` is created when `add demodata` command is run
 ### Fixed
 - downloading phenotype_annotation.tab file from Monarch Initiative
+- document keys when a demo client is created with the command `pmatcher add demodata`
 
 
 ## [2.5] - 2021-01-20

--- a/patientMatcher/cli/add.py
+++ b/patientMatcher/cli/add.py
@@ -100,8 +100,9 @@ def demodata(ensembl_genes):
     click.echo("Loading demo client: DExter MOrgan with token:DEMO")
     demo_client = dict(
         _id="DExterMOrgan",
-        token="DEMO",
-        url="Demo client URL",
+        created=datetime.datetime.now(),
+        auth_token="DEMO",
+        base_url="Demo client URL",
         contact="demo@patientMatcher.se",
     )
     add_node(mongo_db=mongo_db, obj=demo_client, is_client=True)


### PR DESCRIPTION
### This PR adds | fix #195 
When a demo client is created with the command: `pmatcher add demodata`
- create a "created" key
- rename token to `auth_token`
- rename url to `base_url`

### How to test:
- Run pmatcher add demodata and make sure the created client has the expected keys


### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
