### PR TITLE
Completely remove the patient-similarity dependency

### DIFF
--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -15,7 +15,6 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip install git+https://github.com/Clinical-Genomics/patient-similarity
         pip install -e .
         pip install pytest
         pip install pytest-cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Integrate HPOIC (HPO info content) creation in HPO extensions (decouple from Patient-similarity for HPOIC)
 - All collections are removed and recreated on `add demodata` rerun
 - Demo client with token `DEMO` is created when `add demodata` command is run
+- Remove patient-similarity dependency and replace needed functions with internal code
 ### Fixed
 - downloading phenotype_annotation.tab file from Monarch Initiative
 - document keys when a demo client is created with the command `pmatcher add demodata`

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ RUN apk update
 # Install required libs
 RUN apk --no-cache add git bash
 
-# Install patient_similarity from a fork @ClinicalGenomics
-# Original repo: https://github.com/buske/patient-similarity
-RUN pip install git+https://github.com/Clinical-Genomics/patient-similarity
-
 WORKDIR /home/worker/app
 COPY . /home/worker/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,10 @@ RUN apk --no-cache add git bash
 WORKDIR /home/worker/app
 COPY . /home/worker/app
 
-# Install requirements
-RUN pip install -r requirements.txt
-
 # Install the app
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 
 # Run commands as non-root user
-RUN adduser -D worker
-RUN chown worker:worker -R /home/worker
+RUN adduser -D worker &&\
+chown worker:worker -R /home/worker
 USER worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.8-alpine3.12
 
-LABEL base_image="python:3.8-alpine3.12"
 LABEL about.license="MIT License (MIT)"
 LABEL about.tags="WGS,WES,Rare diseases,VCF,variants,phenotype,OMIM,HPO,variants"
 LABEL about.home="https://github.com/Clinical-Genomics/patientMatcher"

--- a/README.md
+++ b/README.md
@@ -75,12 +75,8 @@ After setting up the restricted access to the server you'll just have to launch 
 ```bash
 mongod --auth --dbpath path_to_database_data
 ```
-The phenotype scoring algorithm of patientMatcher is dependent on [patient-similarity](https://github.com/buske/patient-similarity), which should be installed using this script:
 
-```bash
-pip install git+https://github.com/Clinical-Genomics/patient-similarity
-```
-After installing patient-similarity, clone patientMatcher repository from github using this command:
+Clone patientMatcher repository from github using this command:
 
 ```bash
 git clone https://github.com/Clinical-Genomics/patientMatcher.git
@@ -342,7 +338,7 @@ Phenotype similarity is calculated by taking into account **features and disorde
 - **Patient features**
 are specified by the eventual HPO terms provided for the query patient. **Similarity between HPO features will be equal the maximum similarity score** between two patients **if no disorders (OMIM terms) are provided** for one or both patients.   
 **Otherwise feature similarity score will make up 1/2 of the maximum similarity score**.
-Feature similarity is calculated as the simgic score obtained by comparing HPO terms of a query patient with those from a matching patient using the [patient-similarity software package](https://github.com/buske/patient-similarity).
+Feature similarity is calculated as the simgic score obtained by comparing HPO terms of a query patient with those from a matching patient.
 You can find more information on semantic similarity comparison algorithms in [this paper](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-9-S5-S4)
 
 - **Disorders**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   pmatcher-cli:
     container_name: pmatcher-cli
-    image: clinicalgenomics/patientmatcher
+    build: .
     environment:
       MONGODB_HOST: mongodb
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
@@ -38,7 +38,7 @@ services:
 
   pmatcher-web:
     container_name: pmatcher-web
-    image: clinicalgenomics/patientmatcher
+    build: .
     environment:
       MONGODB_HOST: mongodb
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'

--- a/patientMatcher/match/phenotype_matcher.py
+++ b/patientMatcher/match/phenotype_matcher.py
@@ -10,7 +10,7 @@ from patientMatcher.resources import path_to_hpo_terms, path_to_phenotype_annota
 from patientMatcher.server.extensions import diseases as diseases_extension
 from patientMatcher.server.extensions import hpo as hpo_extension
 from patientMatcher.server.extensions import hpoic
-from patientMatcher.utils.patient import Patient
+from patientMatcher.utils.patient import Patient, pheno_similarity_score_simgic
 
 LOG = logging.getLogger(__name__)
 
@@ -151,10 +151,9 @@ def similarity_wrapper(hpoic, hpo, max_hpo_score, hpo_terms_q, hpo_terms_m):
 
     # Get simgic similarity score for HPO terms comparison
     # Range is 0 to 1, with 0=no similarity and 1=highest similarity
-    score_obj = compare_patients(
-        hpoic=hpoic, patient1=query_patient, patient2=match_patient, scores=["simgic"]
+    simgic_score = pheno_similarity_score_simgic(
+        hpoic=hpoic, patient1=query_patient, patient2=match_patient
     )
-    simgic_score = score_obj.get("simgic")
     relative_simgic_score = simgic_score * max_hpo_score
     return relative_simgic_score
 

--- a/patientMatcher/match/phenotype_matcher.py
+++ b/patientMatcher/match/phenotype_matcher.py
@@ -4,13 +4,13 @@
 import logging
 import os
 
-from patient_similarity import Patient
 from patient_similarity.__main__ import compare_patients
 from patientMatcher.parse.patient import disorders_to_omim, features_to_hpo
 from patientMatcher.resources import path_to_hpo_terms, path_to_phenotype_annotations
 from patientMatcher.server.extensions import diseases as diseases_extension
 from patientMatcher.server.extensions import hpo as hpo_extension
 from patientMatcher.server.extensions import hpoic
+from patientMatcher.utils.patient import Patient
 
 LOG = logging.getLogger(__name__)
 

--- a/patientMatcher/match/phenotype_matcher.py
+++ b/patientMatcher/match/phenotype_matcher.py
@@ -137,7 +137,7 @@ def similarity_wrapper(hpoic, hpo, max_hpo_score, hpo_terms_q, hpo_terms_m):
         term = hpo[term_id]
         if term:
             terms.add(term)
-    query_patient = Patient(id="q", hp_terms=terms)
+    query_patient = Patient(pat_id="q", hp_terms=terms)
 
     # create Patient object from match patient data:
     terms = set()
@@ -145,7 +145,7 @@ def similarity_wrapper(hpoic, hpo, max_hpo_score, hpo_terms_q, hpo_terms_m):
         term = hpo[term_id]
         if term:
             terms.add(term)
-    match_patient = Patient(id="m", hp_terms=terms)
+    match_patient = Patient(pat_id="m", hp_terms=terms)
 
     # Get simgic similarity score for HPO terms comparison
     # Range is 0 to 1, with 0=no similarity and 1=highest similarity

--- a/patientMatcher/match/phenotype_matcher.py
+++ b/patientMatcher/match/phenotype_matcher.py
@@ -4,7 +4,6 @@
 import logging
 import os
 
-from patient_similarity.__main__ import compare_patients
 from patientMatcher.parse.patient import disorders_to_omim, features_to_hpo
 from patientMatcher.resources import path_to_hpo_terms, path_to_phenotype_annotations
 from patientMatcher.server.extensions import diseases as diseases_extension
@@ -120,8 +119,7 @@ def evaluate_pheno_similariy(
 
 
 def similarity_wrapper(hpoic, hpo, max_hpo_score, hpo_terms_q, hpo_terms_m):
-    """A wrapper around patient-similarity repository:
-    https://github.com/buske/patient-similarity.
+    """Calculate patient similarity based on HPO terms from2 patients
 
     Args:
         hpoic(class) : the information content for the HPO

--- a/patientMatcher/utils/patient.py
+++ b/patientMatcher/utils/patient.py
@@ -9,6 +9,15 @@ class Patient(object):
     def __init__(self, id, hp_terms):
         self.id = id
         self.hp_terms = hp_terms
+        self._ancestors = None
+
+    def ancestors(self):
+        if self._ancestors is None:
+            ancestors = set()
+            for term in self.hp_terms:
+                ancestors.update(term.ancestors())
+            self._ancestors = ancestors
+        return self._ancestors
 
 
 def patients(database, ids=None):

--- a/patientMatcher/utils/patient.py
+++ b/patientMatcher/utils/patient.py
@@ -12,12 +12,26 @@ class Patient(object):
         self._ancestors = None
 
     def ancestors(self):
+        """Return all the HPO terms ancestors for a patient"""
         if self._ancestors is None:
             ancestors = set()
             for term in self.hp_terms:
                 ancestors.update(term.ancestors())
             self._ancestors = ancestors
         return self._ancestors
+
+
+def pheno_similarity_score_simgic(hpoic, patient1, patient2):
+    """Compare 2 patients phenotypes using the simgic algorithm"""
+    LOG.info(f"Comparing patient1.id vs patient2.id")
+
+    p1_ancestors = patient1.ancestors()
+    p2_ancestors = patient2.ancestors()
+
+    common_ancestors = p1_ancestors & p2_ancestors  # min
+    all_ancestors = p1_ancestors | p2_ancestors  # max
+
+    return hpoic.information_content(common_ancestors) / hpoic.information_content(all_ancestors)
 
 
 def patients(database, ids=None):

--- a/patientMatcher/utils/patient.py
+++ b/patientMatcher/utils/patient.py
@@ -5,6 +5,12 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
+class Patient(object):
+    def __init__(self, id, hp_terms):
+        self.id = id
+        self.hp_terms = hp_terms
+
+
 def patients(database, ids=None):
     """Get all patients in the database
 

--- a/patientMatcher/utils/patient.py
+++ b/patientMatcher/utils/patient.py
@@ -6,8 +6,8 @@ LOG = logging.getLogger(__name__)
 
 
 class Patient(object):
-    def __init__(self, id, hp_terms):
-        self.id = id
+    def __init__(self, pat_id, hp_terms):
+        self.id = pat_id
         self.hp_terms = hp_terms
         self._ancestors = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 coloredlogs
 Flask
 Flask-Mail
-Flask-Negotiate
+flask-negotiate
 requests
 jsonschema
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
-import os
-import pytest
-import mongomock
 import json
+import os
 from pathlib import Path
-from patientMatcher.server import create_app
+
+import mongomock
+import pytest
 from patientMatcher.resources import path_to_benchmark_patients
+from patientMatcher.server import create_app
 
 DATABASE = "testdb"
 
@@ -235,7 +236,7 @@ def gpx4_patients(json_patients):
 
 @pytest.fixture(scope="function")
 def json_patients(demo_data_path):
-    """ Returns a list of 50 MME test patients from demo data"""
+    """Returns a list of 50 MME test patients from demo data"""
     patients = {}
     with open(demo_data_path) as json_data:
         patients = json.load(json_data)

--- a/tests/match/test_pheno_matching.py
+++ b/tests/match/test_pheno_matching.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 
+from patient_similarity import HPO, HPOIC, Diseases, Patient
+from patient_similarity.__main__ import compare_patients
 from patientMatcher.match.phenotype_matcher import match, similarity_wrapper
 from patientMatcher.parse.patient import mme_patient
 from patientMatcher.resources import path_to_hpo_terms, path_to_phenotype_annotations
-from patient_similarity import HPO, Diseases, HPOIC, Patient
-from patient_similarity.__main__ import compare_patients
 
 PHENOTYPE_ROOT = "HP:0000118"
 
 
 def test_patient_similarity_wrapper():
-    """test the wrapper around this repo: https://github.com/buske/patient-similarity"""
+    """Test the function that calculates the HPO similarity between 2 patients"""
 
     # Create the information-content functionality for the HPO
     hpo = HPO(path_to_hpo_terms, new_root=PHENOTYPE_ROOT)

--- a/tests/match/test_pheno_matching.py
+++ b/tests/match/test_pheno_matching.py
@@ -3,32 +3,18 @@
 from patientMatcher.match.phenotype_matcher import match, similarity_wrapper
 from patientMatcher.parse.patient import mme_patient
 from patientMatcher.resources import path_to_hpo_terms, path_to_phenotype_annotations
-from patientMatcher.server.extensions import diseases as diseases_extension
-from patientMatcher.server.extensions import hpo as hpo_extension
-from patientMatcher.server.extensions import hpoic
+from patientMatcher.server.extensions import diseases, hpo, hpoic
 from patientMatcher.utils.patient import Patient
 
 PHENOTYPE_ROOT = "HP:0000118"
 
 
-def test_patient_similarity_wrapper():
+def test_patient_similarity_wrapper(mock_app):
     """Test the function that calculates the HPO similarity between 2 patients"""
 
-    # Create the information-content functionality for the HPO
-    hpo = hpo_extension(path_to_hpo_terms, new_root=PHENOTYPE_ROOT)
     assert hpo
-    diseases = diseases_extension(path_to_phenotype_annotations)
     assert diseases
-    hpo_ic = hpoic(
-        hpo,
-        diseases,
-        orphanet=None,
-        patients=False,
-        use_disease_prevalence=False,
-        use_phenotype_frequency=False,
-        distribute_ic_to_leaves=False,
-    )
-    assert hpo_ic
+    assert hpoic
 
     query_p_terms = [
         "HP:0008058",
@@ -39,7 +25,7 @@ def test_patient_similarity_wrapper():
 
     # test wrapper by providing same terms for query patient and match patient:
     score = similarity_wrapper(
-        hpoic=hpo_ic,
+        hpoic=hpoic,
         hpo=hpo,
         max_hpo_score=1.0,
         hpo_terms_q=query_p_terms,
@@ -52,7 +38,7 @@ def test_patient_similarity_wrapper():
 
     # test wrapper by providing almost the same terms for query patient and match patient:
     related_pheno_score = similarity_wrapper(
-        hpoic=hpo_ic,
+        hpoic=hpoic,
         hpo=hpo,
         max_hpo_score=1.0,
         hpo_terms_q=query_p_terms,
@@ -65,7 +51,7 @@ def test_patient_similarity_wrapper():
     # provide completely different HPO terms for matching patient
     match_p_terms = ["HP:0003002", "HP:0000218"]  # breast cancer and high palate phenotypes
     unrelated_pheno_score = similarity_wrapper(
-        hpoic=hpo_ic,
+        hpoic=hpoic,
         hpo=hpo,
         max_hpo_score=1.0,
         hpo_terms_q=query_p_terms,

--- a/tests/match/test_pheno_matching.py
+++ b/tests/match/test_pheno_matching.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from patient_similarity import HPO, HPOIC, Diseases, Patient
-from patient_similarity.__main__ import compare_patients
 from patientMatcher.match.phenotype_matcher import match, similarity_wrapper
 from patientMatcher.parse.patient import mme_patient
 from patientMatcher.resources import path_to_hpo_terms, path_to_phenotype_annotations
+from patientMatcher.server.extensions import diseases as diseases_extension
+from patientMatcher.server.extensions import hpo as hpo_extension
+from patientMatcher.server.extensions import hpoic
+from patientMatcher.utils.patient import Patient
 
 PHENOTYPE_ROOT = "HP:0000118"
 
@@ -13,11 +15,11 @@ def test_patient_similarity_wrapper():
     """Test the function that calculates the HPO similarity between 2 patients"""
 
     # Create the information-content functionality for the HPO
-    hpo = HPO(path_to_hpo_terms, new_root=PHENOTYPE_ROOT)
+    hpo = hpo_extension(path_to_hpo_terms, new_root=PHENOTYPE_ROOT)
     assert hpo
-    diseases = Diseases(path_to_phenotype_annotations)
+    diseases = diseases_extension(path_to_phenotype_annotations)
     assert diseases
-    hpoic = HPOIC(
+    hpo_ic = hpoic(
         hpo,
         diseases,
         orphanet=None,
@@ -26,7 +28,7 @@ def test_patient_similarity_wrapper():
         use_phenotype_frequency=False,
         distribute_ic_to_leaves=False,
     )
-    assert hpoic
+    assert hpo_ic
 
     query_p_terms = [
         "HP:0008058",
@@ -37,7 +39,7 @@ def test_patient_similarity_wrapper():
 
     # test wrapper by providing same terms for query patient and match patient:
     score = similarity_wrapper(
-        hpoic=hpoic,
+        hpoic=hpo_ic,
         hpo=hpo,
         max_hpo_score=1.0,
         hpo_terms_q=query_p_terms,
@@ -50,7 +52,7 @@ def test_patient_similarity_wrapper():
 
     # test wrapper by providing almost the same terms for query patient and match patient:
     related_pheno_score = similarity_wrapper(
-        hpoic=hpoic,
+        hpoic=hpo_ic,
         hpo=hpo,
         max_hpo_score=1.0,
         hpo_terms_q=query_p_terms,
@@ -63,7 +65,7 @@ def test_patient_similarity_wrapper():
     # provide completely different HPO terms for matching patient
     match_p_terms = ["HP:0003002", "HP:0000218"]  # breast cancer and high palate phenotypes
     unrelated_pheno_score = similarity_wrapper(
-        hpoic=hpoic,
+        hpoic=hpo_ic,
         hpo=hpo,
         max_hpo_score=1.0,
         hpo_terms_q=query_p_terms,


### PR DESCRIPTION
And implement the HPO similarity calculation (simgic algorithm) locally.

Fix #172 

**How to prepare for test**:
- Create a fresh conda environment with python 3.8
- Install the repo

### How to test:
- run a patient matching query with a patient that has HPO terms

### Expected outcome:
- Match results should be returned. These matchings should have the same scores as master branch.

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
