### PR TITLE
Created a demo docker-compose file with 2 other connected nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [] -
 ### Added
+- A demo docker-compose file with a MME server connected to 2 other nodes under `/containers`
 ### Changed
 ### Fixed
 

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -1,0 +1,102 @@
+version: '3'
+# usage:
+# sudo docker-compose up
+services:
+  mongodb:
+    # Lightweight Docker image for MongoDB which makes it easy to create:
+    # - admin
+    # - database
+    # - database user with password
+    # when the container is first launched.
+    image: vepo/mongo
+    container_name: mongo
+    networks:
+      - pmatcher-net
+    environment:
+      - AUTH=y
+      - ADMIN_USER=root
+      - ADMIN_PASS=admin123
+      - APPLICATION_DATABASE=pmatcher
+      - APPLICATION_USER=pmUser
+      - APPLICATION_PASS=pmPassword
+    ports:
+      - '27013:27017'
+    expose:
+      - '27017'
+
+  pmatcher-cli:
+    container_name: pmatcher-cli
+    build: .
+    environment:
+      MONGODB_HOST: mongodb
+      PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
+    depends_on:
+      - mongodb
+    networks:
+      - pmatcher-net
+    command: bash -c "pmatcher add demodata --ensembl_genes"
+
+  # Simulate an external MME server connected to pmatcher-web
+  mme-server-1:
+    container_name: server-1
+    build: .
+    environment:
+      MONGODB_HOST: mongodb
+      PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
+    depends_on:
+      - mongodb
+    networks:
+      - pmatcher-net
+    ports:
+      - '9021:9021'
+    expose:
+      - '9021'
+    command: bash -c "
+      pmatcher add client -id pmatcher_demo -token pmatcher_token1 -url pmatcher_url
+      && pmatcher run --host 0.0.0.0 -p 9021"
+
+  # Simulate a second external MME server connected to pmatcher-web
+  mme-server-2:
+    container_name: server-2
+    build: .
+    environment:
+      MONGODB_HOST: mongodb
+      PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
+    depends_on:
+      - mongodb
+    networks:
+      - pmatcher-net
+    ports:
+      - '9022:9022'
+    expose:
+      - '9022'
+    command: bash -c "
+      pmatcher add client -id pmatcher_demo -token pmatcher_token2 -url pmatcher_url
+      && pmatcher run --host 0.0.0.0 -p 9022"
+
+  pmatcher-web:
+    container_name: pmatcher-web
+    build: .
+    environment:
+      MONGODB_HOST: mongodb
+      PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
+    depends_on:
+      - mongodb
+    networks:
+      - pmatcher-net
+    ports:
+      - '9020:9020'
+    expose:
+      - '9020'
+    command: bash -c "
+      pmatcher add node -id server1 -label 'Demo Server 1' -token pmatcher_token1 -matching_url http://mme-server-1:9021/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
+      && pmatcher add node -id server2 -label 'Demo Server 2' -token pmatcher_token2 -matching_url http://mme-server-2:9022/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
+      && pmatcher run --host 0.0.0.0 -p 9020"
+
+networks:
+  pmatcher-net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.24.0.0/24

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -26,7 +26,7 @@ services:
 
   pmatcher-cli:
     container_name: pmatcher-cli
-    build: .
+    build: ../.
     environment:
       MONGODB_HOST: mongodb
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
@@ -39,7 +39,7 @@ services:
   # Simulate an external MME server connected to pmatcher-web
   mme-server-1:
     container_name: server-1
-    build: .
+    build: ../.
     environment:
       MONGODB_HOST: mongodb
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
@@ -58,7 +58,7 @@ services:
   # Simulate a second external MME server connected to pmatcher-web
   mme-server-2:
     container_name: server-2
-    build: .
+    build: ../.
     environment:
       MONGODB_HOST: mongodb
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
@@ -76,7 +76,7 @@ services:
 
   pmatcher-web:
     container_name: pmatcher-web
-    build: .
+    build: ../.
     environment:
       MONGODB_HOST: mongodb
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'


### PR DESCRIPTION
fix #199 -> The other 2 nodes are other instances of patientMatcher.

The idea is to provide a complete example of a server containing demo data that:
- can be queried directly sending a request containing a json patient
- is capable of sending queries to other connected nodes searching for patients similar to a given patient id

**How to prepare for test**:
- All containers with the command: `docker-compose --file containers/docker-compose_server_with_2_nodes.yml up`
- Edit scout config settings to integrate patientMatcher (pmatcher-web service):
```
MME_ACCEPTS = "application/vnd.ga4gh.matchmaker.v1.0+json"
MME_URL = "http://localhost:9020"
MME_TOKEN = "DEMO"
```

### How to test:
- Run scout and make sure that the MME options show the 2 connected nodes: `server-1` and `server-2`
- Add demo patient to patientMatcher
- Make sure that running queries on either of the connected nodes (or both) returns results.

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
