### PR TITLE
Use different ids for different connected nodes in demo docker-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - A demo docker-compose file with a MME server connected to 2 other nodes under `/containers`
 ### Changed
 ### Fixed
+- Assign 2 different ids to the demo connected nodes in docker-compose
 
 ## [2.6] - 2021-08-11
 ### Added

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -71,7 +71,7 @@ services:
     expose:
       - '9022'
     command: bash -c "
-      pmatcher add client -id pmatcher_demo -token pmatcher_token2 -url pmatcher_url
+      pmatcher add client -id pmatcher_demo2 -token pmatcher_token2 -url pmatcher_url2
       && pmatcher run --host 0.0.0.0 -p 9022"
 
   pmatcher-web:


### PR DESCRIPTION
### This PR adds | fixes:
The current demo docker-compose with the 2 different connected nodes uses the same node id for both nodes: Since it's not possible to save in MongoDB 2 documents with the same ID, only the first node is created. All queries against the second node (using node 2 token) result in an not authorized response from the server:

This PR introduces different node IDs for different nodes

### How to test:
- run the docker-compose document: `docker-compose --file containers/docker-compose_server_with_2_nodes.yml up`
- launch a specific query on the second connected node

### Expected outcome:
- The response should not be "not authorized"

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
