### PR TITLE
Fixed wed server container port launched with docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 ### Fixed
 - Assign 2 different ids to the demo connected nodes in docker-compose
+- Fixed in README file the server port used by the web server container launched from docker-compose
 
 ## [2.6] - 2021-08-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker-compose up -d
 The command will create 3 containers:
 - mongodb: starting a mongodb server with support for user authentication (--auth option)
 - pmatcher-cli: the a command-line app, which will connect to the server and populates it with demo data
-- pmatcher-web: a web server running on localhost and port 27017.
+- pmatcher-web: a web server running on localhost and port 9020.
 
 The server will be running and accepting requests sent from outside the containers (another terminal or a web browser). Read further down to find out about requests and commands.
 


### PR DESCRIPTION
Fix #203 - The web container port launched with docker-compose is 9020 and not 27017 (that is the MongoDB port).

### How to test:
- No test, it's docs

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
