### PR TITLE
Fix setup file so it's processed by twine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 ### Fixed
 - Fixed in README file the server port used by the web server container launched from docker-compose
+- Provide a content type description for long_description in setup file
 
 ## [2.7] - 2021-09-07
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,13 @@ import io
 import os
 import sys
 from shutil import rmtree
+
 from patientMatcher import __version__ as version
-from setuptools import find_packages, setup, Command
+from setuptools import Command, find_packages, setup
 
 # Package meta-data.
 NAME = "patientMatcher"
-DESCRIPTION = "a python-based Matchmaker Exchange server"
+DESCRIPTION = "A python and MongoDB-based Matchmaker Exchange server"
 URL = "https://github.com/Clinical-Genomics/patientMatcher"
 EMAIL = "chiara.rasi@scilifelab.se"
 AUTHOR = "Chiara Rasi"
@@ -111,6 +112,7 @@ setup(
     version=version,
     description=DESCRIPTION,
     long_description=long_description,
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     url=URL,


### PR DESCRIPTION
### This PR adds | fixes:
There is a problem with the twine check command, so it's not possible to publish the package to PyPI:

![image](https://user-images.githubusercontent.com/28093618/133751912-cd4dbaaf-112b-487a-916b-f7d5e09a2d9b.png)


With this fix:

![image](https://user-images.githubusercontent.com/28093618/133752003-92bb04be-7fb4-471c-a5fd-45feb021541f.png)

### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
