### PR TITLE
Fixed syntax in the disclaimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 ### Changed
 ### Fixed
+- Syntax in the disclaimer
 
 ## [2.8] - 2021-09-17
 ### Added

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -29,7 +29,7 @@ MAX_RESULTS = 5
 SCORE_THRESHOLD = 0
 
 # Disclaimer. This text is returned along with match results or server metrics
-DISCLAIMER = "patientMatcher provides data in good faith as a research tool. patientMatcher makes no warranty nor assumes any legal responsibility for any purpose for which the data are used. Users should not attempt in any case to identify patients whose data is returned by the service. Users who intend to publish papers using this software should acknowledge patientMatcher and its developers (https://www.scilifelab.se/facilities/clinical-genomics-stockholm/)."
+DISCLAIMER = """PatientMatcher provides data in good faith as a research tool and makes no warranty nor assumes any legal responsibility for any purpose for which the data is used. Users should not attempt in any case to identify patients whose data is returned by the service. Users who intend to publish papers using this software should acknowledge PatientMatcher and its developers (https://www.scilifelab.se/facilities/clinical-genomics-stockholm/)."""
 
 # Email notification params.
 # Required only if you want to send match notifications to patients contacts


### PR DESCRIPTION
### This PR adds | fixes:
- Fixes the DISCLAIMER syntax on this repo (partial fix #209)

### How to test:
- Bo test, it's just a change in a text.

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
