### PR TITLE
Removed a parameter the `--ensembl_genes` from `add demodata` in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [] -
 ### Added
 ### Changed
+- Improve docker-compose file with 2 demo connected nodes
 ### Fixed
+- Removed unused `--ensembl_genes` parameter from `add demodata` command in all docker-compose file
 
 ## [2.9] - 2021-09-22
 ### Added

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -89,8 +89,8 @@ services:
     expose:
       - '9020'
     command: bash -c "
-      pmatcher add node -id MME-node-1 -label 'MME node 1' -token pmatcher_token1 -matching_url http://mme-server-1:9021/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
-      && pmatcher add node -id MME-node-2 -label 'MME node 2' -token pmatcher_token2 -matching_url http://mme-server-2:9022/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
+      pmatcher add node -id server1 -label 'Demo Server 1' -token pmatcher_token1 -matching_url http://mme-server-1:9021/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
+      && pmatcher add node -id server2 -label 'Demo Server 2' -token pmatcher_token2 -matching_url http://mme-server-2:9022/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
       && pmatcher run --host 0.0.0.0 -p 9020"
 
 networks:

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -34,11 +34,14 @@ services:
       - mongodb
     networks:
       - pmatcher-net
-    command: bash -c "pmatcher add demodata --ensembl_genes"
+    command: bash -c "
+      pmatcher add demodata
+      && pmatcher add node -id MME-node-1 -label 'MME Node 1' -token AAAAAAA -matching_url http://mme-server-1:9021/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
+      && pmatcher add node -id MME-node-2 -label 'MME Node 2' -token BBBBBBB -matching_url http://mme-server-2:9022/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json"
 
   # Simulate an external MME server connected to pmatcher-web
   mme-server-1:
-    container_name: server-1
+    container_name: MME-node-1
     build: ../.
     environment:
       MONGODB_HOST: mongodb
@@ -52,12 +55,12 @@ services:
     expose:
       - '9021'
     command: bash -c "
-      pmatcher add client -id pmatcher_demo -token pmatcher_token1 -url pmatcher_url
+      pmatcher add client -id patientMatcher -token AAAAAAA -url pmatcher_url
       && pmatcher run --host 0.0.0.0 -p 9021"
 
   # Simulate a second external MME server connected to pmatcher-web
   mme-server-2:
-    container_name: server-2
+    container_name: MME-node-2
     build: ../.
     environment:
       MONGODB_HOST: mongodb
@@ -71,7 +74,7 @@ services:
     expose:
       - '9022'
     command: bash -c "
-      pmatcher add client -id pmatcher_demo2 -token pmatcher_token2 -url pmatcher_url2
+      pmatcher add client -id patientMatcher -token BBBBBBB -url pmatcher_url
       && pmatcher run --host 0.0.0.0 -p 9022"
 
   pmatcher-web:
@@ -88,10 +91,7 @@ services:
       - '9020:9020'
     expose:
       - '9020'
-    command: bash -c "
-      pmatcher add node -id server1 -label 'Demo Server 1' -token pmatcher_token1 -matching_url http://mme-server-1:9021/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
-      && pmatcher add node -id server2 -label 'Demo Server 2' -token pmatcher_token2 -matching_url http://mme-server-2:9022/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
-      && pmatcher run --host 0.0.0.0 -p 9020"
+    command: bash -c 'pmatcher run --host 0.0.0.0 -p 9020'
 
 networks:
   pmatcher-net:

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -34,14 +34,11 @@ services:
       - mongodb
     networks:
       - pmatcher-net
-    command: bash -c "
-      pmatcher add demodata
-      && pmatcher add node -id MME-node-1 -label 'MME Node 1' -token AAAAAAA -matching_url http://mme-server-1:9021/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
-      && pmatcher add node -id MME-node-2 -label 'MME Node 2' -token BBBBBBB -matching_url http://mme-server-2:9022/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json"
+    command: bash -c "pmatcher add demodata"
 
   # Simulate an external MME server connected to pmatcher-web
   mme-server-1:
-    container_name: MME-node-1
+    container_name: server-1
     build: ../.
     environment:
       MONGODB_HOST: mongodb
@@ -55,12 +52,12 @@ services:
     expose:
       - '9021'
     command: bash -c "
-      pmatcher add client -id patientMatcher -token AAAAAAA -url pmatcher_url
+      pmatcher add client -id pmatcher_demo -token pmatcher_token1 -url pmatcher_url
       && pmatcher run --host 0.0.0.0 -p 9021"
 
   # Simulate a second external MME server connected to pmatcher-web
   mme-server-2:
-    container_name: MME-node-2
+    container_name: server-2
     build: ../.
     environment:
       MONGODB_HOST: mongodb
@@ -74,7 +71,7 @@ services:
     expose:
       - '9022'
     command: bash -c "
-      pmatcher add client -id patientMatcher -token BBBBBBB -url pmatcher_url
+      pmatcher add client -id pmatcher_demo2 -token pmatcher_token2 -url pmatcher_url2
       && pmatcher run --host 0.0.0.0 -p 9022"
 
   pmatcher-web:
@@ -91,7 +88,10 @@ services:
       - '9020:9020'
     expose:
       - '9020'
-    command: bash -c 'pmatcher run --host 0.0.0.0 -p 9020'
+    command: bash -c "
+      pmatcher add node -id MME-node-1 -label 'MME node 1' -token pmatcher_token1 -matching_url http://mme-server-1:9021/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
+      && pmatcher add node -id MME-node-2 -label 'MME node 2' -token pmatcher_token2 -matching_url http://mme-server-2:9022/match -accepted_content application/vnd.ga4gh.matchmaker.v1.0+json
+      && pmatcher run --host 0.0.0.0 -p 9020"
 
 networks:
   pmatcher-net:

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -82,6 +82,8 @@ services:
       PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
     depends_on:
       - mongodb
+      - mme-server-1
+      - mme-server-2
     networks:
       - pmatcher-net
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - mongodb
     networks:
       - pmatcher-net
-    command: bash -c "pmatcher add demodata --ensembl_genes"
+    command: bash -c "pmatcher add demodata"
 
   pmatcher-web:
     container_name: pmatcher-web


### PR DESCRIPTION
### This PR adds | fixes:
- Removed a parameter the `--ensembl_genes` parameter that is no longer used by the `add demodata` command in all docker-compose files

**How to prepare for test**:
- Launch Docker
- Run `docker-compose --file containers/docker-compose_server_with_2_nodes.yml up`

### How to test:
- Make sure that matching against the patients from these nodes returns results

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
