### PR TITLE
Replaced vepo/mongo with mongo:4.4.9 and created mongo-init.js 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Added
 ### Changed
 - Improve docker-compose file with 2 demo connected nodes
+- Replaced vepo/mongo with mongo:4.4.9 in docker-compose files
+- Created a mongo-init script for using authentication in docker-compose instances
 ### Fixed
 - Removed unused `--ensembl_genes` parameter from `add demodata` command in all docker-compose file
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ### Added
 ### Changed
 - Improve docker-compose file with 2 demo connected nodes
-- Replaced vepo/mongo with mongo:4.4.9 in docker-compose files
-- Created a mongo-init script for using authentication in docker-compose instances
+- Replaced vepo/mongo with the official MongoDB image mongo:4.4.9 in docker-compose files
+- Created a mongo-init script for database authentication in docker-compose instances
 ### Fixed
 - Removed unused `--ensembl_genes` parameter from `add demodata` command in all docker-compose file
 

--- a/containers/docker-compose_server_with_2_nodes.yml
+++ b/containers/docker-compose_server_with_2_nodes.yml
@@ -3,26 +3,22 @@ version: '3'
 # sudo docker-compose up
 services:
   mongodb:
-    # Lightweight Docker image for MongoDB which makes it easy to create:
-    # - admin
-    # - database
-    # - database user with password
-    # when the container is first launched.
-    image: vepo/mongo
-    container_name: mongo
+    # Using the official MongoDB image 4.4.9
+    image: mongo:4.4.9
+    container_name: mongodb
     networks:
       - pmatcher-net
-    environment:
-      - AUTH=y
-      - ADMIN_USER=root
-      - ADMIN_PASS=admin123
-      - APPLICATION_DATABASE=pmatcher
-      - APPLICATION_USER=pmUser
-      - APPLICATION_PASS=pmPassword
     ports:
       - '27013:27017'
     expose:
       - '27017'
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root123
+      MONGO_INITDB_DATABASE: admin
+    volumes: # Invoke an init script that creates an authenticated user for the database
+      - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    restart: always
 
   pmatcher-cli:
     container_name: pmatcher-cli

--- a/containers/mongo-init.js
+++ b/containers/mongo-init.js
@@ -1,0 +1,10 @@
+print('########### Setting up PatientMatcher database user ###########');
+
+db = db.getSiblingDB('pmatcher');
+db.createUser(
+   {
+     user: "pmUser",
+     pwd: "pmPassword",
+     roles: [ "dbOwner" ]
+   }
+)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,26 +3,22 @@ version: '3'
 # sudo docker-compose up
 services:
   mongodb:
-    # Lightweight Docker image for MongoDB which makes it easy to create:
-    # - admin
-    # - database
-    # - database user with password
-    # when the container is first launched.
-    image: vepo/mongo
-    container_name: mongo
+    # Using the official MongoDB image 4.4.9
+    image: mongo:4.4.9
+    container_name: mongodb
     networks:
       - pmatcher-net
-    environment:
-      - AUTH=y
-      - ADMIN_USER=root
-      - ADMIN_PASS=admin123
-      - APPLICATION_DATABASE=pmatcher
-      - APPLICATION_USER=pmUser
-      - APPLICATION_PASS=pmPassword
     ports:
       - '27013:27017'
     expose:
       - '27017'
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root123
+      MONGO_INITDB_DATABASE: admin
+    volumes: # Invoke an init script that creates an authenticated user for the database
+      - ./containers/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    restart: always
 
   pmatcher-cli:
     container_name: pmatcher-cli


### PR DESCRIPTION
### This PR adds | fixes:
- Replaced vepo/mongo with mongo:4.4.9 in docker-compose files (fix #218)
- Created a mongo-init script for using authentication in docker-compose instances

This change was a bit tricky since **PatientMatcher is an app that is using MongoDB authentication** (is already like this in production), which means a database user and password params should be created and the app should be able to connect using these params. [vepo/mongo](https://github.com/vepo/mongo) was easy to use since you could provide all the params as environmental variables. Switching to the official mongo image I've found out that you can provide some scripts when launching the database that basically create the database user and password. I've followed these instructions: https://onexlab-io.medium.com/docker-compose-mongodb-prod-dev-test-environment-eb1a75675f93

**How to prepare for test**:
Remove any local PatientMatcher container

### How to test:
- docker-compose up (all the containers should start with no problems)
- in another terminal run: `curl -X GET localhost:9020/metrics` -> It should give you the stats from patientMatcher database
- docker-compose down

### Expected outcome:
It should work nicely

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
