### PR TITLE
Bulk update patients contact info from the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [] -
+### Changed
+- Improve views code by reusing a controllers function when request auth fails
+### added
+- Bulk replace patients' contact info using the command line
+
 ## [2.10.2] - 2021-11-12
 ### Fixed
 - Increase MongoDB connection serverSelectionTimeoutMS to 30K (defeult value accorfing to MongoDB socumentation)

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -25,9 +25,10 @@ def update():
 )
 def contact(old_href, href, name, institution):
     """Update contact person for a group of patients"""
-    # Retrieve all patients that need to be updated
-    query = {"contact.href": {"$regex": old_href}}
+
     database = current_app.db
+    query = {"contact.href": {"$regex": old_href}}
+
     # Retrieving all patients matching the given old_href
     old_contact_patients = patients(database=database, match_query=query)
     # Retriving unique contacts for the above patients

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -36,23 +36,23 @@ def contact(old_href, href, name, institution):
     if len(match_contacts) == 0:
         click.echo(f"No patients found with contact URI '{old_href}'")
         return
-    elif len(match_contacts) > 1:
+    if len(match_contacts) > 1:
         click.echo(
             f"Your search for contact url '{old_href}' is returning more than one patients' contact: {match_contacts}.\nPlease restrict your search by typing a different href."
         )
         return
-    else:  # Search is returning only one contact, ok to use it for updating patients
-        matches = list(old_contact_patients)
-        new_contact = dict(href=href, name=name)
-        if institution:
-            new_contact["institution"] = institution
+    # Search is returning only one contact, it's OK to use it for updating patients
+    matches = list(old_contact_patients)
+    new_contact = dict(href=href, name=name)
+    if institution:
+        new_contact["institution"] = institution
 
-        if click.confirm(
-            f"{len(matches)} patients with the old contact href '{matches[0]['contact']['href']}' will be updated with contact info:{new_contact}. Confirm?",
-            abort=True,
-        ):
-            result = database.patients.update_many(query, {"$set": {"contact": new_contact}})
-            click.echo(f"Contact information was updated for {result.modified_count} patients.")
+    if click.confirm(
+        f"{len(matches)} patients with the old contact href '{matches[0]['contact']['href']}' will be updated with contact info:{new_contact}. Confirm?",
+        abort=True,
+    ):
+        result = database.patients.update_many(query, {"$set": {"contact": new_contact}})
+        click.echo(f"Contact information was updated for {result.modified_count} patients.")
 
 
 @update.command()

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -1,16 +1,58 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import click
 import requests
 from clint.textui import progress
-import click
+from flask.cli import current_app, with_appcontext
 from patientMatcher.constants import PHENOTYPE_TERMS
+from patientMatcher.utils.patient import patients
 
 
 @click.group()
 def update():
     """Update patientMatcher resources"""
     pass
+
+
+@update.command()
+@with_appcontext
+@click.option("-old-href", type=click.STRING, nargs=1, required=True, help="Old contact href")
+@click.option("-href", type=click.STRING, nargs=1, required=True, help="New contact href")
+@click.option("-name", type=click.STRING, nargs=1, required=True, help="New contact name")
+@click.option(
+    "-institution", type=click.STRING, nargs=1, required=False, help="New contact institution"
+)
+def contact(old_href, href, name, institution):
+    """Update contact person for a group of patients"""
+    # Retrieve all patients that need to be updated
+    query = {"contact.href": {"$regex": old_href}}
+    database = current_app.db
+    # Retrieving all patients matching the given old_href
+    old_contact_patients = patients(database=database, match_query=query)
+    # Retriving unique contacts for the above patients
+    match_contacts = list(old_contact_patients.distinct("contact.href"))
+
+    if len(match_contacts) == 0:
+        click.echo(f"No patients found with contact URI '{old_href}'")
+        return
+    elif len(match_contacts) > 1:
+        click.echo(
+            f"Your search for contact url '{old_href}' is returning more than one patients' contact: {match_contacts}.\nPlease restrict your search by typing a different href."
+        )
+        return
+    else:  # Search is returning only one contact, ok to use it for updating patients
+        matches = list(old_contact_patients)
+        new_contact = dict(href=href, name=name)
+        if institution:
+            new_contact["institution"] = institution
+
+        if click.confirm(
+            f"{len(matches)} patients with the old contact href '{matches[0]['contact']['href']}' will be updated with contact info:{new_contact}. Confirm?",
+            abort=True,
+        ):
+            result = database.patients.update_many(query, {"$set": {"contact": new_contact}})
+            click.echo(f"Contact information was updated for {result.modified_count} patients.")
 
 
 @update.command()

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 import logging
+
 from flask import jsonify
 from jsonschema import ValidationError
+from patientMatcher.__version__ import __version__
+from patientMatcher.auth.auth import authorize
 from patientMatcher.constants import STATUS_CODES
-from patientMatcher.utils.stats import general_metrics
+from patientMatcher.match.handler import external_matcher
+from patientMatcher.parse.patient import mme_patient, validate_api
 from patientMatcher.utils.delete import delete_by_query
 from patientMatcher.utils.patient import patients
-from patientMatcher.parse.patient import validate_api, mme_patient
-from patientMatcher.auth.auth import authorize
-from patientMatcher.match.handler import external_matcher
-from patientMatcher.__version__ import __version__
+from patientMatcher.utils.stats import general_metrics
 
 LOG = logging.getLogger(__name__)
+
+
+def reassign_patients():
+    """Reassign all patients with a given contact to another contact"""
 
 
 def heartbeat(disclaimer):

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from urllib.parse import urlparse
 
 from flask import jsonify
 from jsonschema import ValidationError
@@ -13,10 +14,6 @@ from patientMatcher.utils.patient import patients
 from patientMatcher.utils.stats import general_metrics
 
 LOG = logging.getLogger(__name__)
-
-
-def reassign_patients():
-    """Reassign all patients with a given contact to another contact"""
 
 
 def heartbeat(disclaimer):

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -51,7 +51,7 @@ def get_nodes(database):
 def patient(database, patient_id):
     """Return a mme-like patient from database by providing its ID"""
     query_patient = None
-    query_result = list(patients(database, ids=[patient_id]))
+    query_result = list(patients(database=database, ids=[patient_id]))
     if query_result:
         query_patient = query_result[0]
     return query_patient

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -19,11 +19,21 @@ blueprint = Blueprint("server", __name__)
 API_MIME_TYPE = "application/vnd.ga4gh.matchmaker.v1.0+json"
 
 
+@blueprint.route("/patient/reassign", methods=["POST"])
+def reassign():
+    """Update the contact information for one or more patients"""
+
+    if not authorize(current_app.db, request):  # not authorized, return a 401 status code
+        return controllers.bad_request(401)
+
+    controllers.reassign_patients(current_app.db, request)
+
+
 @blueprint.route("/patient/add", methods=["POST"])
 @consumes(API_MIME_TYPE, "application/json")
 @produces("application/json")
 def add():
-    """Add patient to database"""
+    """Add a patient to the database"""
 
     formatted_patient = controllers.check_request(current_app.db, request)
     if isinstance(formatted_patient, int):  # some error must have occurred during validation
@@ -64,13 +74,11 @@ def add():
 
 @blueprint.route("/patient/delete/<patient_id>", methods=["DELETE"])
 def delete(patient_id):
+    """Delete a patient from the database using its ID"""
     # check if request is authorized
     resp = None
     if not authorize(current_app.db, request):  # not authorized, return a 401 status code
-        message = STATUS_CODES[401]["message"]
-        resp = jsonify(message)
-        resp.status_code = 401
-        return resp
+        return controllers.bad_request(401)
 
     LOG.info("Authorized client is removing patient with id {}".format(patient_id))
     message = controllers.delete_patient(current_app.db, patient_id)
@@ -112,10 +120,7 @@ def nodes():
     """Get a list of all nodes connected to this MME server"""
     resp = None
     if not authorize(current_app.db, request):
-        message = STATUS_CODES[401]["message"]
-        resp = jsonify(message)
-        resp.status_code = 401
-        return resp
+        return controllers.bad_request(401)
 
     LOG.info("Authorized client requests list of connected nodes..")
     results = controllers.get_nodes(database=current_app.db)
@@ -131,10 +136,7 @@ def matches(patient_id):
     resp = None
     message = {}
     if not authorize(current_app.db, request):  # not authorized, return a 401 status code
-        message = STATUS_CODES[401]["message"]
-        resp = jsonify(message)
-        resp.status_code = 401
-        return resp
+        return controllers.bad_request(401)
 
     # return only matches with at least one result
     results = patient_matches(current_app.db, patient_id)
@@ -155,10 +157,7 @@ def match_external(patient_id):
     resp = None
     message = {}
     if not authorize(current_app.db, request):  # not authorized, return a 401 status code
-        message["message"] = STATUS_CODES[401]["message"]
-        resp = jsonify(message)
-        resp.status_code = 401
-        return resp
+        return controllers.bad_request(401)
 
     LOG.info(
         "Authorized clients is matching patient with ID {} against external nodes".format(

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -19,16 +19,6 @@ blueprint = Blueprint("server", __name__)
 API_MIME_TYPE = "application/vnd.ga4gh.matchmaker.v1.0+json"
 
 
-@blueprint.route("/patient/reassign", methods=["POST"])
-def reassign():
-    """Update the contact information for one or more patients"""
-
-    if not authorize(current_app.db, request):  # not authorized, return a 401 status code
-        return controllers.bad_request(401)
-
-    controllers.reassign_patients(current_app.db, request)
-
-
 @blueprint.route("/patient/add", methods=["POST"])
 @consumes(API_MIME_TYPE, "application/json")
 @produces("application/json")

--- a/patientMatcher/utils/patient.py
+++ b/patientMatcher/utils/patient.py
@@ -34,12 +34,13 @@ def pheno_similarity_score_simgic(hpoic, patient1, patient2):
     return hpoic.information_content(common_ancestors) / hpoic.information_content(all_ancestors)
 
 
-def patients(database, ids=None):
+def patients(database, ids=None, match_query=None):
     """Get all patients in the database
 
     Args:
         database(pymongo.database.Database)
         ids(list): a list of IDs to return only specified patients
+        match_query(dict): use a query to match and retrieve patients from the database
 
     Returns:
         results(Iterable[dict]): list of patients from mongodb patients collection
@@ -49,7 +50,9 @@ def patients(database, ids=None):
     if ids:  # if only specified patients should be returned
         LOG.info("Querying patients for IDs {}".format(ids))
         query["_id"] = {"$in": ids}
-
+    elif match_query:
+        LOG.info("Return patients matching query {}".format(match_query))
+        query = match_query
     else:
         LOG.info("Return all patients in database")
 

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,10 +1,47 @@
 from patientMatcher.cli.commands import cli
 
 
-def test_cli_update_resources(mock_app):
-
+def test_update_resources(mock_app):
+    """Test the command that updates the database resources (diseases and HPO terms)"""
     runner = mock_app.test_cli_runner()
 
     # run resources update command with --test flag:
     result = runner.invoke(cli, ["update", "resources", "--test"])
     assert result.exit_code == 0
+
+
+def test_update_contact(mock_app, gpx4_patients):
+    """Test the command to bulk-update patients contact"""
+
+    runner = mock_app.test_cli_runner()
+    patients_collection = mock_app.db.patients
+
+    # GIVEN a database with some patients
+    patients_collection.insert_many(gpx4_patients)
+    test_patients = patients_collection.find()
+    # Sharing a contact information
+    contacts = test_patients.distinct("contact.href")
+    assert len(contacts) == 1
+
+    # WHEN their contact info is updated using the cli
+    new_href = "new.contact@mail.com"
+    result = runner.invoke(
+        cli,
+        [
+            "update",
+            "contact",
+            "-old-href",
+            contacts[0],
+            "-href",
+            new_href,
+            "-name",
+            "New Name",
+            "-institution",
+            "Test Institution",
+        ],
+        input="y",
+    )
+
+    # THEN the config info should be updated
+    updated_patient = patients_collection.find({"contact.href": new_href})
+    assert len(list(updated_patient)) > 0


### PR DESCRIPTION
### This PR adds | fixes:
### Changed
- Improve views code by reusing a controllers function when request auth fails
### added
- Bulk replace patients' contact info using the command line

**How to prepare for test**:
- [ ] Load demo data into the server with the command pmatcher add demodata
- [ ] Update the contact info with href `http://www.ncbi.nlm.nih.gov/pubmed/25105227` with some contact info of your choice

### How to test:
Run the command:
```
pmatcher update contact -old-href 25105227 -href some.email@mail.com -name "Some Name"
```

### Expected outcome:
- [ ] 6 patients should be updated!

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
