### PR TITLE
Add documentation on how to update patients' contact info using the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 - Improve views code by reusing a controllers function when request auth fails
 ### added
 - Bulk replace patients' contact info using the command line
+- Documentation on how to update patients contact info using the command line
 
 ## [2.10.2] - 2021-11-12
 ### Fixed
-- Increase MongoDB connection serverSelectionTimeoutMS to 30K (defeult value accorfing to MongoDB socumentation)
+- Increase MongoDB connection serverSelectionTimeoutMS to 30K (default value according to MongoDB documentation)
 
 ## [2.10.1] - 2021-10-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## [] -
 ### Changed
 - Improve views code by reusing a controllers function when request auth fails
-### added
+### Added
 - Bulk replace patients' contact info using the command line
-- Documentation on how to update patients contact info using the command line
+- Documentation on how to update patients' contact info using the command line
 
 ## [2.10.2] - 2021-11-12
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Table of Contents:
 5. [ Command line interface](#cli)
     - [ Adding demo data to server](#cli_add_demo)
     - [ Removing a patient from database ](#cli_remove_patient)
+    - [ Updating patients' contact info using the command line](#cli_update_contacts)
     - [ Adding a client to database ](#cli_add_client)
     - [ Adding a new connected node to database ](#cli_add_node)
 6. [ Server endpoints ](#endpoints)
@@ -144,6 +145,33 @@ Options:
 -label TEXT  label of the patient to be removed from database
 ```
 &nbsp;&nbsp;
+
+<a name="cli_update_contacts"></a>
+### Updating patients' contact info using the command line
+Contact information is a mandatory descriptor for each patient and represents the primary contact email address or URL used when looking for additional information for a patient in case of positive matches triggered by other patients from external nodes or the same database. A patient contact is described in PatientMatcher (and in the MatchMaker Exchange API) by these key/values:
+
+- **href**: a string represented by a URL (example: http://www.ncbi.nlm.nih.gov/pubmed/23542699) or an email address (example: mailto:someone@somesite.com). This field is mandatory.
+- **name**: complete name of a person responsible for the patient. This field is mandatory.
+- **institution**: the Institution the contact person for the patients belongs to. This information is optional.
+
+The command to update patients' contact info is the following:
+```bash
+pmatcher update contact [OPTIONS]
+
+  Update contact person for a group of patients
+
+Options:
+  -old-href TEXT     Old contact href  [required]
+  -href TEXT         New contact href  [required]
+  -name TEXT         New contact name  [required]
+  -institution TEXT  New contact institution
+```
+
+Let's assume a group of patients has a contact `Peter Parker` with href `pparker@example.com`. To replace the old user contact in **all patients** with new contact, for instance `Bruce Wayne`, type:
+
+```bash
+pmatcher update contact -old-href pparker@example.com -href bwayne@example.com -name "Bruce Wayne" -institution "Wayne Enterprises, Inc."
+```
 
 <a name="cli_add_client"></a>
 ### Adding a client to the database

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Options:
 ### Updating patients' contact info using the command line
 Contact information is a mandatory descriptor for each patient and represents the primary contact email address or URL used when looking for additional information for a patient in case of positive matches triggered by other patients from external nodes or the same database. A patient contact is described in PatientMatcher (and in the MatchMaker Exchange API) by these key/values:
 
-- **href**: a string represented by a URL (example: http://www.ncbi.nlm.nih.gov/pubmed/23542699) or an email address (example: mailto:someone@somesite.com). This field is mandatory.
-- **name**: complete name of a person responsible for the patient. This field is mandatory.
+- **href**: a string represented by a URL (example: http://www.ncbi.nlm.nih.gov/pubmed/23542699) or the email address of the contact user (example: mailto:someone@somesite.com). This field is mandatory.
+- **name**: complete name of the contact user responsible for the patient saved in the MatchMaker. This field is mandatory.
 - **institution**: the Institution the contact person for the patients belongs to. This information is optional.
 
 The command to update patients' contact info is the following:


### PR DESCRIPTION
### This PR adds | fixes:
- Add documentation on how to update patients' contact info using the command line

### How to test:
- No test needed, it just has to make sense.

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
