### PR TITLE
Validate patient contact href when saving or updating patients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Bulk replace patients' contact info using the command line
 - Documentation on how to update patients' contact info using the command line
+- Contact href string validation when saving or updating patients
 
 ## [2.10.2] - 2021-11-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Bulk replace patients' contact info using the command line
 - Documentation on how to update patients' contact info using the command line
-- Contact href string validation when saving or updating patients
+- Contact href string validation (schemas: http, https, mailto) when saving or updating patients
 
 ## [2.10.2] - 2021-11-12
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ Options:
   -institution TEXT  New contact institution
 ```
 
-Let's assume a group of patients has a contact `Peter Parker` with href `pparker@example.com`. To replace the old user contact in **all patients** with new contact, for instance `Bruce Wayne`, type:
+Let's assume a group of patients has a contact `Peter Parker` with href `mailto:pparker@example.com`. To replace the old user contact in **all patients** with the new contact info, for instance `Bruce Wayne`, type:
 
 ```bash
-pmatcher update contact -old-href pparker@example.com -href bwayne@example.com -name "Bruce Wayne" -institution "Wayne Enterprises, Inc."
+pmatcher update contact -old-href maito:pparker@example.com -href mailto:bwayne@example.com -name "Bruce Wayne" -institution "Wayne Enterprises, Inc."
 ```
 
 <a name="cli_add_client"></a>

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -36,7 +36,7 @@ def contact(old_href, href, name, institution):
 
     if href_validate(href) is False:
         LOG.error(
-            "Provided href does not have a valid schema. Provide either a URL (http, https) or an email address (mailto)"
+            "Provided href does not have a valid schema. Provide either a URL (http://.., https://..) or an email address (mailto:..)"
         )
         return
 

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -6,6 +6,7 @@ import requests
 from clint.textui import progress
 from flask.cli import current_app, with_appcontext
 from patientMatcher.constants import PHENOTYPE_TERMS
+from patientMatcher.parse.patient import href_validator
 from patientMatcher.utils.patient import patients
 
 

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import logging
 
 import click
 import requests
 from clint.textui import progress
 from flask.cli import current_app, with_appcontext
 from patientMatcher.constants import PHENOTYPE_TERMS
-from patientMatcher.parse.patient import href_validator
+from patientMatcher.parse.patient import EMAIL_REGEX, href_validate
 from patientMatcher.utils.patient import patients
+
+LOG = logging.getLogger(__name__)
 
 
 @click.group()
@@ -26,6 +29,16 @@ def update():
 )
 def contact(old_href, href, name, institution):
     """Update contact person for a group of patients"""
+
+    # If new contact is a simple email, add "mailto" schema
+    if bool(EMAIL_REGEX.match(href)) is True:
+        href = ":".join(["mailto", href])
+
+    if href_validate(href) is False:
+        LOG.error(
+            "Provided href does not have a valid schema. Provide either a URL (http, https) or an email address (mailto)"
+        )
+        return
 
     database = current_app.db
     query = {"contact.href": {"$regex": old_href}}

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -28,7 +28,7 @@ def href_validate(href):
         if result.scheme == "mailto":  # mailto:me@example.com
             # validate email
             return bool(EMAIL_REGEX.match(href.split("mailto:")[1]))
-        return all([result.scheme, result.netloc, result.path]) and result.scheme in [
+        return all([result.scheme, result.netloc]) and result.scheme in [
             "http",
             "https",
         ]

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -28,9 +28,8 @@ def href_validate(href):
         if result.scheme == "mailto":  # mailto:me@example.com
             # validate email
             return bool(EMAIL_REGEX.match(href.split("mailto:")[1]))
-        else:  # result.scheme = http, https ..
-            return all([result.scheme, result.netloc])
-    except:
+        return all([result.scheme, result.netloc])
+    except Exception as ex:
         return False
 
 

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -28,7 +28,10 @@ def href_validate(href):
         if result.scheme == "mailto":  # mailto:me@example.com
             # validate email
             return bool(EMAIL_REGEX.match(href.split("mailto:")[1]))
-        return all([result.scheme, result.netloc])
+        return all([result.scheme, result.netloc, result.path]) and result.scheme in [
+            "http",
+            "https",
+        ]
     except Exception as ex:
         return False
 

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -1,15 +1,37 @@
 # -*- coding: utf-8 -*-
-
 import json
-from copy import deepcopy
-from jsonschema import validate, RefResolver, FormatChecker
-from patientMatcher.utils.gene import symbol_to_ensembl, entrez_to_symbol, ensembl_to_symbol
-from patientMatcher.utils.variant import liftover
-from pkgutil import get_data
 import logging
+import re
+from copy import deepcopy
+from pkgutil import get_data
+from urllib.parse import urlparse
+
+from jsonschema import FormatChecker, RefResolver, validate
+from patientMatcher.utils.gene import ensembl_to_symbol, entrez_to_symbol, symbol_to_ensembl
+from patientMatcher.utils.variant import liftover
 
 LOG = logging.getLogger(__name__)
 SCHEMA_FILE = "api.json"
+EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
+
+
+def href_validate(href):
+    """Validates the URL used as contact href for the patient
+
+    Args:
+        href(str): A string provided by the user as patient's contact href
+    Returns:
+        True if it's a valid URL or False if it isn't
+    """
+    try:
+        result = urlparse(href)
+        if result.scheme == "mailto":  # mailto:me@example.com
+            # validate email
+            return bool(EMAIL_REGEX.match(href.split("mailto:")[1]))
+        else:  # result.scheme = http, https ..
+            return all([result.scheme, result.netloc])
+    except:
+        return False
 
 
 def mme_patient(json_patient, convert_to_ensembl=False):

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -41,9 +41,10 @@ def test_update_contact(mock_app, gpx4_patients):
         ],
         input="y",
     )
+    assert result.exit_code == 0
 
     # THEN the config info should be updated
-    updated_patient = patients_collection.find({"contact.href": new_href})
+    updated_patient = patients_collection.find({"contact.href": ":".join(["mailto", new_href])})
     assert len(list(updated_patient)) > 0
 
 
@@ -82,9 +83,10 @@ def test_update_contact_no_href_match(mock_app, gpx4_patients):
             "Test Institution",
         ],
     )
+    assert result.exit_code == 0
 
     # THEN no patients contact should be updated
-    assert patients_collection.find_one({"contact.href": new_href}) is None
+    assert patients_collection.find_one({"contact.href": ":".join(["mailto", new_href])}) is None
 
 
 def test_update_contact_multiple_href_match(mock_app, gpx4_patients):
@@ -119,4 +121,4 @@ def test_update_contact_multiple_href_match(mock_app, gpx4_patients):
     )
 
     # THEN no patients contact should be updated
-    assert patients_collection.find_one({"contact.href": new_href}) is None
+    assert patients_collection.find_one({"contact.href": ":".join(["mailto", new_href])}) is None

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -1,11 +1,32 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from patientMatcher.parse.patient import (
-    features_to_hpo,
     disorders_to_omim,
-    mme_patient,
+    features_to_hpo,
     gtfeatures_to_variants,
+    href_validate,
+    mme_patient,
 )
+
+
+def test_href_validate_wrong_url():
+    """Test href_validate function with a malformed URL"""
+    assert href_validate("google") is False
+
+
+def test_href_validate_valid_url():
+    """Test href_validate function with a valid URL"""
+    assert href_validate("http://google.com") is True
+
+
+def test_href_validate_wrong_email():
+    """Test href_validate function with a mailto link and wrong email syntax"""
+    assert href_validate("mailto:foo@a") is False
+
+
+def test_href_validate_valid_email():
+    """Test href_validate function with a mailto link and valid email"""
+    assert href_validate("mailto:me@patientmatcher.se") is True
 
 
 def test_features_to_hpo_no_features():

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -21,7 +21,7 @@ def test_href_validate_valid_url():
 
 def test_href_validate_wrong_email():
     """Test href_validate function with a mailto link and wrong email syntax"""
-    assert href_validate("mailto:foo@a") is False
+    assert href_validate("me@patientmatcher.se") is False
 
 
 def test_href_validate_valid_email():

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -30,19 +30,19 @@ def test_href_validate_valid_email():
 
 
 def test_features_to_hpo_no_features():
-    # Make sure the function returns [] if patient doesn't have HPO terms
+    """Make sure the function returns [] if patient doesn't have associated HPO terms"""
     result = features_to_hpo(None)
     assert result == []
 
 
 def test_disorders_to_omim_no_omim():
-    # Make sure the function returns [] if patient doesn't have OMIM terms
+    """Make sure the function returns [] if patient doesn't have associated OMIM terms"""
     result = disorders_to_omim(None)
     assert result == []
 
 
 def test_mme_patient_gene_symbol(gpx4_patients, database):
-    # Test format a patient with HGNC gene symbol
+    """Test format a patient with HGNC gene symbol"""
 
     test_patient = gpx4_patients[0]
     gene_name = test_patient["genomicFeatures"][0]["gene"]["id"]  # "GPX4"
@@ -55,7 +55,7 @@ def test_mme_patient_gene_symbol(gpx4_patients, database):
 
 
 def test_mme_patient_entrez_gene(entrez_gene_patient, database):
-    # Test format a patient with entrez gene
+    """Test format a patient with entrez gene"""
     # Before conversion patient's gene id is an entrez gene ID
     assert entrez_gene_patient["genomicFeatures"][0]["gene"]["id"] == "3735"
     mme_formatted_patient = mme_patient(entrez_gene_patient, True)  # convert genes to Ensembl
@@ -66,7 +66,6 @@ def test_mme_patient_entrez_gene(entrez_gene_patient, database):
 
 def test_gtfeatures_to_variants(patient_37):
     """Test the function that parses variants dictionaries from patient's genomic features"""
-
     # GIVEN a patient containing 1 genomic feature (and one variant)
     gt_features = patient_37["patient"]["genomicFeatures"]
     assert len(gt_features) == 1

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -238,6 +238,8 @@ def test_update_patient(mock_app, test_client, gpx4_patients, test_node, databas
     """Test updating a patient by sending a POST request to the add endpoint with valid data"""
 
     patient_data = gpx4_patients[1]
+    # Modify patient's contact href with a simple email
+    patient_data["contact"]["href"] = "somebody@test.se"
 
     # Given a node with authorized token
     ok_token = test_client["auth_token"]
@@ -269,8 +271,9 @@ def test_update_patient(mock_app, test_client, gpx4_patients, test_node, databas
     assert response.status_code == 200
 
     # Then there should still be one patient in the database
-    results = database["patients"].find()
-    assert len(list(results)) == 1
+    updated_patient = database["patients"].find_one()
+    # With an updated and valid email address
+    assert updated_patient["contact"]["href"] == "mailto:somebody@test.se"
 
     # And the update has triggered an additional external patient matching
     results = database["matches"].find()


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #229 -> Provided patient contact href must be either a valid URL or email address (format mailto:somename@test.se)

**How to prepare for test**:
- [x] Add demodata and launch the server locally:
```
pmatcher add demodata
pmatcher run --port 9020
```
### How to test:
- [x] Try to update the contact href of one or more patients using the command line, providing a wrong url format
- [x] Try to update the contact href of one or more patients using the command line, providing a wrong email format
- [x] Try adding a patient using the API, providing a wrong url format
- [x] Try adding a patient using the API, providing a wrong email format

### Expected outcome:
- [x] All these attempt should fail, and only correctly formatted URLs or emails should be saved for patients contact in the database.

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
