### PR TITLE
Fix deprecated code causing warnings during automatic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [] -
+### Fixed
+- Fix some deprecated code causing warnings during automatic tests
 ### Changed
 - Improve views code by reusing a controllers function when request auth fails
 ### Added

--- a/patientMatcher/utils/delete.py
+++ b/patientMatcher/utils/delete.py
@@ -14,7 +14,7 @@ def drop_all_collections(mongo_db):
         mongo_db(pymongo.database.Database)
     """
     LOG.warning(f"Dropping all existing collections in database")
-    for collection in mongo_db.collection_names():
+    for collection in mongo_db.list_collection_names():
         mongo_db[collection].drop()
 
 

--- a/patientMatcher/utils/disease.py
+++ b/patientMatcher/utils/disease.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from patientMatcher.resources import path_to_phenotype_annotations
 
 LOG = logging.getLogger(__name__)
-db_re = re.compile("([A-Z]+:\d+)")
+db_re = re.compile(r"([A-Z]+:\d+)")
 
 FREQUENCY_TERMS = {
     "HP:0040280": 1.0,  # Obligate

--- a/tests/backend/test_backend_patient.py
+++ b/tests/backend/test_backend_patient.py
@@ -28,7 +28,7 @@ def test_load_demo_patients(demo_data_path, database):
 
 
 def test_backend_remove_patient(gpx4_patients, database):
-    """ Test adding 2 test patients and then removing them using label or ID """
+    """Test adding 2 test patients and then removing them using label or ID"""
 
     # test conversion to format required for the database:
     test_mme_patients = [mme_patient(json_patient=patient) for patient in gpx4_patients]

--- a/tests/utils/test_delete.py
+++ b/tests/utils/test_delete.py
@@ -6,11 +6,11 @@ def test_drop_all_collections(demo_data_path, database):
     """Test the functions that drop all existent collections from database before populating demo database"""
     # GIVEN a populated database
     load_demo_patients(demo_data_path, database)
-    collections = database.collection_names()
+    collections = database.list_collection_names()
     assert collections
 
     # WHEN drop_all_collections is invoked
     drop_all_collections(database)
-    collections = database.collection_names()
+    collections = database.list_collection_names()
     # THEN no collections should be found in database
     assert collections == []


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #214 

### How to test:
- Automatic tests should not complain about deprecated code any more. And they should pass of course!

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
