### PR TITLE
Do not duplicate mailto schema when patient contact email has already the right format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Fixed
 - Fix some deprecated code causing warnings during automatic tests
+- Do not duplicate `mailto` schema when contact href is an email with correct schema
 ### Changed
 - Improve views code by reusing a controllers function when request auth fails
 ### Added

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -31,7 +31,7 @@ def contact(old_href, href, name, institution):
     """Update contact person for a group of patients"""
 
     # If new contact is a simple email, add "mailto" schema
-    if bool(EMAIL_REGEX.match(href)) is True:
+    if bool(EMAIL_REGEX.match(href)) is True and not "mailto:" in contact_href:
         href = ":".join(["mailto", href])
 
     if href_validate(href) is False:

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -31,7 +31,7 @@ def contact(old_href, href, name, institution):
     """Update contact person for a group of patients"""
 
     # If new contact is a simple email, add "mailto" schema
-    if bool(EMAIL_REGEX.match(href)) is True and not "mailto:" in contact_href:
+    if bool(EMAIL_REGEX.match(href)) is True and not "mailto:" in href:
         href = ":".join(["mailto", href])
 
     if href_validate(href) is False:

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -23,15 +23,13 @@ def href_validate(href):
     Returns:
         True if it's a valid URL or False if it isn't
     """
+    LOG.warning(f"Passed href is {href}")
     try:
         result = urlparse(href)
         if result.scheme == "mailto":  # mailto:me@example.com
             # validate email
             return bool(EMAIL_REGEX.match(href.split("mailto:")[1]))
-        return all([result.scheme, result.netloc]) and result.scheme in [
-            "http",
-            "https",
-        ]
+        return all([result.scheme, result.netloc]) and result.scheme in ["http", "https", "mailto"]
     except Exception as ex:
         return False
 

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -94,7 +94,7 @@ def check_request(database, request):
     contact_href = request_json["patient"]["contact"]["href"]
 
     # If new contact is a simple email, add "mailto" schema
-    if bool(EMAIL_REGEX.match(contact_href)) is True:
+    if bool(EMAIL_REGEX.match(contact_href)) is True and not "mailto:" in contact_href:
         contact_href = ":".join(["mailto", contact_href])
         request_json["patient"]["contact"]["href"] = contact_href
 
@@ -103,9 +103,6 @@ def check_request(database, request):
             "Provided contact href does not have a valid schema - either a URL (http://.., https://..) or an email address (mailto:..)"
         )
         return 422
-
-    # if href_validate(request_json["contact"]["href"]) is False:
-    #    LOG.warning("Patient's contact href not con")
 
     formatted_patient = mme_patient(json_patient=request_json["patient"], convert_to_ensembl=True)
     return formatted_patient


### PR DESCRIPTION
# This PR fixes a bug. 
To reproduce:
- Load demo data
- Update contact href for one or more patients providing a new href with this format: `mailto:me@myself.com`
- Notice that the command will fail because the href passed to the validator will be mailto:mailto:me@myself.com

This PR fixes this problem

### How to test:
- Switch to this branch and try the commands above

### Expected outcome:
- [x] This time the validation should pass and the command will be executed

### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
