### PR TITLE
Scan only changed files using vulture

### DIFF
--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -17,5 +17,5 @@ jobs:
         uses: anaynayak/python-vulture-action@v1.0
         id: vulture
         with:
-          vulture-args: . --min-confidence 80 ${{steps.files.outputs.all}}
+          vulture-args: --min-confidence 80 ${{steps.files.outputs.all}}
         continue-on-error: true

--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -8,9 +8,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Find changed files
+        id: files
+        uses: jitterbit/get-changed-files@v1
+
       - name: Scavenge
         uses: anaynayak/python-vulture-action@v1.0
         id: vulture
         with:
-          vulture-args: . --min-confidence 90
+          vulture-args: . --min-confidence 80 ${{steps.files.outputs.all}}
         continue-on-error: true

--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -9,9 +9,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Find changed files
+      - name: Find changed Python files
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.0.0
+        with:
+          filter: "*.py"
 
       - name: Scavenge
         uses: anaynayak/python-vulture-action@v1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Removed unused imports
 ### added
 - Vulture GitHub action to flag unused code with 90% confidence
+### Changed
+- Scan only changed files with Vulture action
 
 ## [2.11] - 2021-11-16
 ### Fixed

--- a/patientMatcher/cli/add.py
+++ b/patientMatcher/cli/add.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-
 import datetime
 
 import click


### PR DESCRIPTION
### This PR adds changed the Vulture github action to scan only the files changed in the PR.

### How to test:
- Vulture should not report any problems with setup.py in this PR

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
