### PR TITLE
Fix app wsgi and run Docker prod app via Gunicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [] -
+### Changed
+- Docker base image to run the app via Docker and Gunicorn in a prod environment
 ### Fixed
 - Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
+- Deprecated werkzeug.contrib preventing running the docker app in prod environment
 
 ## [2.12] - 2021-11-24
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-FROM python:3.8-alpine3.12
+FROM tiangolo/uvicorn-gunicorn:python3.8-slim
 
 LABEL about.license="MIT License (MIT)"
 LABEL about.tags="WGS,WES,Rare diseases,VCF,variants,phenotype,OMIM,HPO,variants"
 LABEL about.home="https://github.com/Clinical-Genomics/patientMatcher"
 
-RUN apk update
-# Install required libs
-RUN apk --no-cache add git bash
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install -y --no-install-recommends bash
+
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 10001 --create-home worker
 
 WORKDIR /home/worker/app
 COPY . /home/worker/app
+
+# Install the app requirements
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Install the app
 RUN pip install --no-cache-dir -e .
 
 # Run commands as non-root user
-RUN adduser -D worker &&\
-chown worker:worker -R /home/worker
 USER worker
+
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,14 @@ LABEL about.home="https://github.com/Clinical-Genomics/patientMatcher"
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install -y --no-install-recommends bash
+    apt-get -y install -y --no-install-recommends bash && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 10001 --create-home worker
 
 WORKDIR /home/worker/app
 COPY . /home/worker/app
-
-# Install the app requirements
-RUN pip install --no-cache-dir -r requirements.txt
 
 # Install the app
 RUN pip install --no-cache-dir -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,3 @@ RUN pip install --no-cache-dir -e .
 
 # Run commands as non-root user
 USER worker
-
-ENTRYPOINT ["/bin/bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - mongodb
     networks:
       - pmatcher-net
-    command: bash -c "pmatcher add demodata"
+    command: -c 'pmatcher add demodata'
 
   pmatcher-web:
     container_name: pmatcher-web
@@ -43,7 +43,7 @@ services:
       - '9020:9020'
     expose:
       - '9020'
-    command: bash -c 'pmatcher run --host 0.0.0.0 -p 9020'
+    command: -c 'pmatcher run --host 0.0.0.0 -p 9020'
 
 networks:
   pmatcher-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       - '9020:9020'
     expose:
       - '9020'
-    command: -c 'pmatcher run --host 0.0.0.0 -p 9020'
+    command: -c 'gunicorn --workers=2 --bind="localhost:9020" --timeout=400 \
+        --access-logfile=- --error-logfile=- patientMatcher.server.auto:app'
 
 networks:
   pmatcher-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,7 @@ services:
       - '9020:9020'
     expose:
       - '9020'
-    command: -c 'gunicorn --workers=2 --bind="localhost:9020" --timeout=400 \
-        --access-logfile=- --error-logfile=- patientMatcher.server.auto:app'
+    command: -c 'gunicorn --workers=2 --bind="0.0.0.0:9020" --timeout=400 --access-logfile=- --error-logfile=- patientMatcher.server.auto:app'
 
 networks:
   pmatcher-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - mongodb
     networks:
       - pmatcher-net
-    command: -c 'pmatcher add demodata'
+    command: bash -c 'pmatcher add demodata'
 
   pmatcher-web:
     container_name: pmatcher-web
@@ -43,7 +43,7 @@ services:
       - '9020:9020'
     expose:
       - '9020'
-    command: -c 'gunicorn --workers=2 --bind="0.0.0.0:9020" --timeout=400 --access-logfile=- --error-logfile=- patientMatcher.server.auto:app'
+    command: bash -c 'gunicorn --workers=2 --bind="0.0.0.0:9020" --timeout=400 --access-logfile=- --error-logfile=- patientMatcher.server.auto:app'
 
 networks:
   pmatcher-net:

--- a/patientMatcher/server/auto.py
+++ b/patientMatcher/server/auto.py
@@ -1,4 +1,8 @@
-from werkzeug.middleware.proxy_fix import ProxyFix
+try:
+    from werkzeug.contrib.fixers import ProxyFix
+except ModuleNotFoundError:
+    # Werkzeug >1.0 moved the library to middleware : https://github.com/pallets/werkzeug/issues/1477
+    from werkzeug.middleware.proxy_fix import ProxyFix
 
 from patientMatcher.server import create_app
 

--- a/patientMatcher/server/auto.py
+++ b/patientMatcher/server/auto.py
@@ -1,4 +1,4 @@
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from patientMatcher.server import create_app
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fixes bug #245, that is preventing to run a prod app via Docker
- Modified the Dockerfile base image to use one that contains gunicorn
- Modified docker-compose file to illustrate running the dockerized app via Gunicorn

**How to prepare for test**:
- [x] Run docker-compose up
- [x] The app cli should populate the database with data
- [x] The app web server should run on localhost:9020

### How to test:
- In another terminal, run `curl localhost:9020/metrics` and it should return the server stats

<hr> 

### Additional test: running the cli and the web app by running the image (as you would do from podman)
- Remove all related containers, images and dangling stuff
- Having a running instance of MongoDB reachable on localhost, port 27017:
- Build the image: `docker build -t pm-image .`
- l**aunch a container to load the demo data into the database (cli)**: 
From a Mac terminal: `docker run --rm --env MONGODB_HOST=host.docker.internal --name pm-cli pm-image pmatcher add demodata`
From a linux terminal: `docker run --rm --network host --name pm-cli pm-image pmatcher add demodata`
- **Launch a container to start the web app via gunicorn** 
From a Mac terminal:  `docker run --publish 8000:8000 --env MONGODB_HOST=host.docker.internal --name pm-web pm-image gunicorn --workers=2 --bind 0.0.0.0 patientMatcher.server.auto:app`
From a linux terminal: `docker run --network host --publish 8000:8000 --name pm-web pm-image gunicorn --workers=2 --bind 0.0.0.0 patientMatcher.server.auto:app`
- In another terminal, run `curl localhost:8000/metrics` and it should return the server stats


### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
