### PR TITLE
Dockerfile for pmatcher + Dockerfile for server

### DIFF
--- a/.github/workflows/docker_build_n_publish.yml
+++ b/.github/workflows/docker_build_n_publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Docker Hub
+name: Publish main image and server image to Docker Hub
 
 on:
  release:
@@ -13,10 +13,19 @@ jobs:
     - name: Check out git repository
       uses: actions/checkout@v2
 
-    - name: Publish to Registry
+    - name: Publish main image (Dockerfile) to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: clinicalgenomics/patientmatcher
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ github.event.release.tag_name }}"
+
+    - name: Publish server image (Dockerfile-server) to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: clinicalgenomics/patientmatcher-server
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: Dockerfile-server
         tags: "latest,${{ github.event.release.tag_name }}"

--- a/.github/workflows/docker_build_n_publish_stage.yml
+++ b/.github/workflows/docker_build_n_publish_stage.yml
@@ -32,6 +32,6 @@ jobs:
        uses: docker/build-push-action@v2
        with:
          context: ./
-         file: ./Dockerfile
+         file: ./Dockerfile-server
          push: true
-         tags: "clinicalgenomics/patientmatcher-stage:${{steps.branch-name.outputs.current_branch}}, clinicalgenomics/patientmatcher-stage:latest"
+         tags: "clinicalgenomics/patientmatcher-server-stage:${{steps.branch-name.outputs.current_branch}}, clinicalgenomics/patientmatcher-server-stage:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - GitHub action to push staging branches from pull requests to Docker Hub
 ### Changed
 - Docker base image to run the app via Docker and Gunicorn in a prod environment
+- Created another Dockerfile to run the app via gunicorn
+- Extended config file functionality to collect all required params from environment variables
 ### Fixed
 - Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
 - Deprecated werkzeug.contrib preventing running the docker app in prod environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 ## [] -
 ### added
 - GitHub action to push staging branches from pull requests to Docker Hub
+- Created another Dockerfile to run the app via gunicorn
+- Modified  GitHub actions to push Dockerfile-server image (stage) to Docker Hub when a pull request is opened or modified
 ### Changed
 - Docker base image to run the app via Docker and Gunicorn in a prod environment
 - Created another Dockerfile to run the app via gunicorn
 - Extended config file functionality to collect all required params from environment variables
+- Modified README to describe the two distinct Dockerfiles
+- Modified the docker-compose to provide an example on how to use the two Dockerfiles
+- Modified  GitHub actions to push both Dockerfile and Dockerfile-server images (prod) to Docker Hub when a new release is created
 ### Fixed
 - Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
 - Deprecated werkzeug.contrib preventing running the docker app in prod environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
-FROM tiangolo/uvicorn-gunicorn:python3.8-slim
+FROM clinicalgenomics/python3.8-venv:1.0
 
 LABEL about.license="MIT License (MIT)"
 LABEL about.tags="WGS,WES,Rare diseases,VCF,variants,phenotype,OMIM,HPO,variants"
 LABEL about.home="https://github.com/Clinical-Genomics/patientMatcher"
 
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get -y install -y --no-install-recommends bash && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Install and run commands from virtual environment
+RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
 
-RUN groupadd --gid 1000 worker && useradd -g worker --uid 10001 --create-home worker
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --create-home worker
 
 WORKDIR /home/worker/app
 COPY . /home/worker/app
 
-# Install the app
 RUN pip install --no-cache-dir -e .
 
 # Run commands as non-root user
 USER worker
+
+ENTRYPOINT ["pmatcher"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,17 @@ LABEL about.tags="WGS,WES,Rare diseases,VCF,variants,phenotype,OMIM,HPO,variants
 LABEL about.home="https://github.com/Clinical-Genomics/patientMatcher"
 
 # Install and run commands from virtual environment
-RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+RUN python3 -m venv /home/worker/venv
+ENV PATH="/home/worker/venv/bin:$PATH"
 
+# Create a non-root user to run commands
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --create-home worker
 
 WORKDIR /home/worker/app
 COPY . /home/worker/app
+
+# make sure all messages always reach console
+ENV PYTHONUNBUFFERED=1
 
 RUN pip install --no-cache-dir -e .
 

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -5,17 +5,19 @@ ENV GUNICORN_THREADS=1
 ENV GUNICORN_BIND="0.0.0.0:8000"
 ENV GUNICORN_TIMEOUT=400
 
-# Install and run commands from virtual environment
-sudo RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+# Set virtual environment as root
+USER root
+ENV PATH="/venv/bin:$PATH"
+RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+
+# Install gunicorn
+RUN pip install --no-cache-dir gunicorn
 
 # Run commands as non-root user
 USER worker
 
 WORKDIR /home/worker/app
 COPY . /home/worker/app
-
-# Install Gunicorn
-RUN pip install --no-cache-dir gunicorn
 
 CMD gunicorn \
     --workers=$GUNICORN_WORKERS \

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,23 +1,45 @@
-FROM clinicalgenomics/patientmatcher-stage:latest
+###########
+# BUILDER #
+###########
+
+FROM clinicalgenomics/python3.8-venv:1.0 AS builder
+
+# Install and run commands from virtual environment
+RUN python3 -m venv /home/worker/venv
+ENV PATH="/home/worker/venv/bin:$PATH"
+
+# install requirements
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+#########
+# FINAL #
+#########
+
+FROM clinicalgenomics/python3.8-venv:1.0 AS deployer
+
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --create-home worker
+COPY --chown=worker:worker --from=builder /home/worker/venv /home/worker/venv
+
+RUN mkdir /home/worker/app
+WORKDIR /home/worker/app
+COPY . .
+
+USER worker
+
+# make sure all messages always reach console
+ENV PYTHONUNBUFFERED=1
+
+# activate virtual environment
+ENV VIRTUAL_ENV=/home/worker/venv
+ENV PATH="/home/worker/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir gunicorn
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1
 ENV GUNICORN_BIND="0.0.0.0:8000"
 ENV GUNICORN_TIMEOUT=400
-
-# Set virtual environment as root
-USER root
-ENV PATH="/venv/bin:$PATH"
-RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
-
-# Install gunicorn
-RUN pip install --no-cache-dir gunicorn
-
-# Run commands as non-root user
-USER worker
-
-WORKDIR /home/worker/app
-COPY . /home/worker/app
 
 CMD gunicorn \
     --workers=$GUNICORN_WORKERS \

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,0 +1,33 @@
+FROM clinicalgenomics/patientMatcher-stage:latest
+
+ENV GUNICORN_WORKERS=1
+ENV GUNICORN_THREADS=1
+ENV GUNICORN_BIND="0.0.0.0:8000"
+ENV GUNICORN_TIMEOUT=400
+
+# Install and run commands from virtual environment
+RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+
+RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --create-home worker
+
+WORKDIR /home/worker/app
+COPY . /home/worker/app
+
+# Install Gunicorn
+RUN pip install --no-cache-dir gunicorn
+
+# Run commands as non-root user
+USER worker
+
+CMD gunicorn \
+    --workers=$GUNICORN_WORKERS \
+    --bind=$GUNICORN_BIND  \
+    --threads=$GUNICORN_THREADS \
+    --timeout=$GUNICORN_TIMEOUT \
+    --proxy-protocol \
+    --forwarded-allow-ips="10.0.2.100,127.0.0.1" \
+    --log-syslog \
+    --access-logfile - \
+    --error-logfile - \
+    --log-level="debug" \
+    patientMatcher.server.auto:app

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM clinicalgenomics/patientMatcher-stage:latest
+FROM clinicalgenomics/patientmatcher-stage:latest
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1
@@ -6,18 +6,16 @@ ENV GUNICORN_BIND="0.0.0.0:8000"
 ENV GUNICORN_TIMEOUT=400
 
 # Install and run commands from virtual environment
-RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+sudo RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
 
-RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --create-home worker
+# Run commands as non-root user
+USER worker
 
 WORKDIR /home/worker/app
 COPY . /home/worker/app
 
 # Install Gunicorn
 RUN pip install --no-cache-dir gunicorn
-
-# Run commands as non-root user
-USER worker
 
 CMD gunicorn \
     --workers=$GUNICORN_WORKERS \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 Table of Contents:
 1. [ Intro ](#intro)
 2. [ Running the app using Docker ](#docker)
+    - [ Running a demo using docker-compose ](#docker)
+    - [ Dockerfile and Dockerfile-server ](#dockerfiles)
 3. [ Installing the app on a virtual environment with a running instance of MongoDB ](#installation)
 4. [ Data types ](#data_types)
 5. [ Command line interface](#cli)
@@ -34,16 +36,17 @@ PatientMatcher is a Python and MongoDB - based implementation of a [MatchMaker E
 
 
 <a name="docker"></a>
-## Running the app using Docker
-An example containing a demo setup for the app is included in the docker-compose file. Note that this file is not intended for use in production and is onpy provided to illustrate how the backend and frontend of the app could be connected to a mongodb instance stored on an external image. Start the docker-compose demo using this command:
+
+## Running an the containing demo data using Docker
+An example containing a demo setup for the app is included in the docker-compose file. Note that this file is not intended for use in production and is only provided to illustrate how the backend and frontend of the app could be connected to a MongoDB instance stored on an external image. Start the docker-compose demo using this command:
 
 ```
 docker-compose up -d
 ```
 The command will create 3 containers:
 - mongodb: starting a mongodb server with support for user authentication (--auth option)
-- pmatcher-cli: the a command-line app, which will connect to the server and populates it with demo data
-- pmatcher-web: a web server running on localhost and port 9020.
+- patientmatcher_cli: the a command-line app, which will connect to the server and populates it with demo data
+- patientmatcher_web: a web server running on localhost and port 9020.
 
 The server will be running and accepting requests sent from outside the containers (another terminal or a web browser). Read further down to find out about requests and commands.
 
@@ -60,8 +63,39 @@ Make sure that there are no mongo containers running before before running the c
 Commands:
 ```
 docker ps -a
-docker rm <id of the eventual vepo/mongo container>
+docker rm <id of the eventual containers' id>
 ```
+<a name="dockerfiles"></a>
+## Dockerfile and Dockerfile-server
+
+You might have noticed that the docker-compose - based demo described above is using two different containers for the same application.
+
+### Dockerfile
+Provides a generic image for the application, that can be used for launching contaiers to run command line commands (such as add demo data to the database, create a node, etc) or run a development app.
+
+- **Given an instance of MongoDB running on localhost, default port 27017**
+
+#### Example on how to run the standard image to populate the database with demo data
+
+* Build the image: `docker build -t pmatcher-image .`
+* Launch a container with the instructions to populate database with demo data: `docker run --rm (--env MONGODB_HOST=host.docker.internal)(--net host) pmatcher-image add demodata`
+
+**--env MONGODB_HOST=host.docker.internal** --> required to be able to access the database on the local Mac OS machine
+
+**--net host** --> required to be able to access the database on a local Linux machine
+
+
+### Dockerfile-server
+Is an image based on the previous one, but contains additional software (gunicorn) and parameters to run patientMatcher in a production environment.
+
+- **Given an instance of MongoDB populated with data, running on localhost, default port 27017**
+
+#### Example on how to launch a production server
+
+* Build the image: `docker build -t server-img -f Dockerfile-server .`
+* Launch a the image containing a server running on localhost, port 8000:
+```docker run --name server -p 8000:8000 --expose 8000 (--env MONGODB_HOST=host.docker.internal)(--net host) server-img```
+
 
 <a name="installation"></a>
 ## Installing the app on a virtual environment with a running instance of MongoDB

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
 
     restart: always
 
-  pmatcher-cli:
-    container_name: pmatcher-cli
+  cli:
+    container_name: cli-app
     build: .
     environment:
       MONGODB_HOST: mongodb
@@ -26,15 +26,22 @@ services:
       - mongodb
     networks:
       - pmatcher-net
-    command: bash -c 'pmatcher add demodata'
+    command: add demodata
 
-  pmatcher-web:
-    container_name: pmatcher-web
-    build: .
+  web:
+    container_name: web-app
+    build: Dockerfile-server
     environment:
       MONGODB_HOST: mongodb
       MONGODB_PORT: 27017
-      PMATCHER_CONFIG: '/home/worker/app/patientMatcher/patientMatcher/instance/config.py'
+      MAX_GT_SCORE: 0.75
+      MAX_PHENO_SCORE: 0.25
+      MAX_RESULTS: 10
+      DISCLAIMER: 'This is a test PatientMatcher server'
+      GUNICORN_WORKERS: 1
+      GUNICORN_TREADS: 1
+      GUNICORN_BIND: 0.0.0.0:9020
+      GUNICORN_TIMEOUT: 400
     depends_on:
       - mongodb
     networks:
@@ -43,7 +50,6 @@ services:
       - '9020:9020'
     expose:
       - '9020'
-    command: bash -c 'gunicorn --workers=2 --bind="0.0.0.0:9020" --timeout=400 --access-logfile=- --error-logfile=- patientMatcher.server.auto:app'
 
 networks:
   pmatcher-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,9 @@ services:
 
   web:
     container_name: web-app
-    build: Dockerfile-server
+    build:
+      context: .
+      dockerfile: Dockerfile-server
     environment:
       MONGODB_HOST: mongodb
       MONGODB_PORT: 27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,21 +42,17 @@ services:
       DISCLAIMER: 'This is a test PatientMatcher server'
       GUNICORN_WORKERS: 1
       GUNICORN_TREADS: 1
-      GUNICORN_BIND: 0.0.0.0:9020
+      GUNICORN_BIND: 0.0.0.0:8000
       GUNICORN_TIMEOUT: 400
     depends_on:
       - mongodb
     networks:
       - pmatcher-net
     ports:
-      - '9020:9020'
+      - '8000:8000'
     expose:
-      - '9020'
+      - '8000'
 
 networks:
   pmatcher-net:
     driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.24.0.0/24

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -1,51 +1,55 @@
 import os
 
 # Turns on debugging features in Flask
-DEBUG = True
+DEBUG = os.getenv("DEBUG") or True
 
 # secret key:
-SECRET_KEY = "MySuperSecretKey"
+SECRET_KEY = os.getenv("SECRET_KEY") or "MySuperSecretKey"
 
-DB_USERNAME = "pmUser"
-DB_PASSWORD = "pmPassword"
-DB_NAME = "pmatcher"
+DB_USERNAME = os.getenv("MONGODB_USER") or "pmUser"
+DB_PASSWORD = os.getenv("MONGODB_PASSWORD") or "pmPassword"
+DB_NAME = os.getenv("MONGODB_DBNAME") or "pmatcher"
 DB_HOST = (
     os.getenv("MONGODB_HOST") or "127.0.0.1"
 )  # simply substitute with 'mongodb' if connecting to MongoDB running in a container
 DB_PORT = os.getenv("MONGODB_PORT") or 27017
 
 # DB_URI = "mongodb://{}:{}@{}:{}/{}".format(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME)
-DB_URI = "mongodb://{}:{}/{}".format(DB_HOST, DB_PORT, DB_NAME)  # without authentication
+DB_URI = os.getenv("MONGODB_DB_URI") or "mongodb://{}:{}/{}".format(
+    DB_HOST, DB_PORT, DB_NAME
+)  # without authentication
 # DB_URI = "mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/?replicaSet=rs0&readPreference=primary"  # MongoDB replica set
-
 
 # Matching Algorithms scores
 # sum of MAX_GT_SCORE and MAX_PHENO_SCORE should be 1
-MAX_GT_SCORE = 0.75
-MAX_PHENO_SCORE = 0.25
+MAX_GT_SCORE = os.getenv("MAX_GT_SCORE") or 0.75
+MAX_PHENO_SCORE = os.getenv("MAX_PHENO_SCORE") or 0.25
 
 # Max results matches returned by server.
-MAX_RESULTS = 5
+MAX_RESULTS = os.getenv("MAX_RESULTS") or 5
 
 # Set a minimum patient score threshold for returned results
 # Set this parameter to 0 to return all results with a score higher than 0
-SCORE_THRESHOLD = 0
+SCORE_THRESHOLD = os.getenv("SCORE_THRESHOLD") or 0
 
 # Disclaimer. This text is returned along with match results or server metrics
-DISCLAIMER = """PatientMatcher provides data in good faith as a research tool and makes no warranty nor assumes any legal responsibility for any purpose for which the data is used. Users should not attempt in any case to identify patients whose data is returned by the service. Users who intend to publish papers using this software should acknowledge PatientMatcher and its developers (https://www.scilifelab.se/facilities/clinical-genomics-stockholm/)."""
+DISCLAIMER = (
+    os.getenv("DISCLAIMER")
+    or """PatientMatcher provides data in good faith as a research tool and makes no warranty nor assumes any legal responsibility for any purpose for which the data is used. Users should not attempt in any case to identify patients whose data is returned by the service. Users who intend to publish papers using this software should acknowledge PatientMatcher and its developers (https://www.scilifelab.se/facilities/clinical-genomics-stockholm/)."""
+)
 
 # Email notification params.
 # Required only if you want to send match notifications to patients contacts
-# MAIL_SERVER = mail_port
-# MAIL_PORT = email_port
-# MAIL_USE_TLS = True or False
-# MAIL_USE_SSL = True or False
-# MAIL_USERNAME = 'user_email@mail.se'
-# MAIL_PASSWORD = 'mail_password'
+MAIL_SERVER = os.getenv("MAIL_SERVER") or None  # "smtp.gmail.com"
+MAIL_PORT = os.getenv("MAIL_PORT") or None  # 587
+MAIL_USE_TLS = os.getenv("MAIL_USE_TLS") or True  # True
+MAIL_USE_SSL = os.getenv("MAIL_USE_SSL") or False  # False
+MAIL_USERNAME = os.getenv("MAIL_USERNAME") or None  # some.email@test.se
+MAIL_PASSWORD = os.getenv("MAIL_PASSWORD") or None  # email_password
 
 # ADMINS will receive email notification is app crashes
-# ADMINS = []
+ADMINS = os.getenv("ADMINS") or []
 
 # Set NOTIFY_COMPLETE to False if you don't want to notify variants and phenotypes by email
 # This way only contact info and matching patients ID will be notified in email body
-# NOTIFY_COMPLETE = True
+NOTIFY_COMPLETE = os.getenv("NOTIFY_COMPLETE") or False


### PR DESCRIPTION
### This PR adds | fixes:
- Created another Dockerfile to run the app via gunicorn
- Extended config file functionality to collect all required params from environment variables
- Modified README to describe the two distinct Dockerfiles
- Modified the docker-compose to provide an example on how to use the two Dockerfiles
- Modified  GitHub actions to push server image to Docker Hub when a pull request is opened or modified
- Modified  GitHub actions to push both standard and server image to Docker Hub when a new release is created

**How to prepare for test**:
- Remove all old and dangling images from local Docker

### How to test:
- [x] Make sure the new Docker-file server can be launched and is reachable on localhost, port 8000
- [x] Launch a demo app using docker-compose and make sure that the metrics endpoint returns data
- [x] Make sure the right images are pushed to DockerHub

### Expected outcome:
- The tests above should be successful

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
