### PR TITLE
Fix metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+### Fixed
+- Restore saving of all matching attempts into database, also those with no results
+
 ## [2.13] - 2021-12-13
 ### added
 - GitHub action to push staging branches from pull requests to Docker Hub

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -30,7 +30,7 @@ MAX_RESULTS = os.getenv("MAX_RESULTS") or 5
 
 # Set a minimum patient score threshold for returned results
 # Set this parameter to 0 to return all results with a score higher than 0
-SCORE_THRESHOLD = 0.065
+SCORE_THRESHOLD = os.getenv("SCORE_THRESHOLD") or 0
 
 # Disclaimer. This text is returned along with match results or server metrics
 DISCLAIMER = (

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -30,7 +30,7 @@ MAX_RESULTS = os.getenv("MAX_RESULTS") or 5
 
 # Set a minimum patient score threshold for returned results
 # Set this parameter to 0 to return all results with a score higher than 0
-SCORE_THRESHOLD = os.getenv("SCORE_THRESHOLD") or 0
+SCORE_THRESHOLD = 0.065
 
 # Disclaimer. This text is returned along with match results or server metrics
 DISCLAIMER = (

--- a/patientMatcher/match/handler.py
+++ b/patientMatcher/match/handler.py
@@ -112,9 +112,7 @@ def internal_matcher(
     sorted_matches = sorted(matches, key=lambda k: k["score"]["patient"], reverse=True)
 
     # this is saved to server, regardless of the results returned by the nodes
-    has_matches = False
-    if sorted_matches:
-        has_matches = True
+    has_matches = bool(sorted_matches)
 
     internal_match = {
         "created": datetime.datetime.now(),

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -7,7 +7,6 @@ from bson import json_util
 from flask import Blueprint, current_app, jsonify, request
 from flask_negotiate import consumes, produces
 from patientMatcher.auth.auth import authorize
-from patientMatcher.constants import STATUS_CODES
 from patientMatcher.match.handler import async_match, internal_matcher, patient_matches
 from patientMatcher.utils.add import backend_add_patient
 from patientMatcher.utils.notify import notify_match_external, notify_match_internal

--- a/patientMatcher/server/views.py
+++ b/patientMatcher/server/views.py
@@ -278,8 +278,7 @@ def match_internal():
         current_app.db, query_patient, max_pheno_score, max_geno_score, max_results, score_threshold
     )
     # save matching object to database
-    if match_obj and (match_obj.get("has_matches") or match_obj.get("errors")):
-        current_app.db["matches"].insert_one(match_obj)
+    current_app.db["matches"].insert_one(match_obj)
     matches = []
     try:
         matches = match_obj["results"][0][


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #252

**How to prepare for test**:
- Edit the config file with this param: `SCORE_THRESHOLD = 0.065` (stricter matching, will not return results with low score)
- Locally, load demo data into the database: `pmatcher add demodata`
- Start the demo server: `pmatcher run`

### How to test:
- From another shell window run a query that will not return results, **twice**:
```
curl -X POST \
  -H 'X-Auth-Token: DEMO' \
  -H 'Content-Type: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -H 'Accept: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -d '{"patient":{
    "id":"patient_id",
    "contact": {"name":"Contact Name", "href":"mailto:contact_name@mail.com"},
    "features":[{"id":"HP:0001298"}]
  }}' localhost:5000/match
```

- From another shell window run a query that will returns results:
```
curl -X POST \
  -H 'X-Auth-Token: DEMO' \
  -H 'Content-Type: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -H 'Accept: application/vnd.ga4gh.matchmaker.v1.0+json' \
  -d '{"patient":{
    "id":"patient_id",
    "contact": {"name":"Contact Name", "href":"mailto:contact_name@mail.com"},
    "features":[{"id":"HP:0009623"}]
  }}' localhost:5000/match

```

### Expected outcome:
- When the test procedure is executed from main branch, the metrics will show 1 for both number of requests received and number of potential matches sent.
- These numbers will differ when testing is done from this branch (3 matching attempts, only 1 returning results),

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
