### PR TITLE
Fix heartbeat endpoint to return to return True or False if server is Prod or stage server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Restore saving of all matching attempts into database, also those with no results
 - Parsing of admins emails list when provided using env vars
+- Heartbeat endpoint to return True or False if the app is prod or staging app
 
 ## [2.13] - 2021-12-13
 ### added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       MAX_RESULTS: 10
       DISCLAIMER: 'This is a test PatientMatcher server'
       ADMINS: '["test@mail.se"]'
-      TESTING: True
+      TESTING: 'True'
       GUNICORN_WORKERS: 1
       GUNICORN_TREADS: 1
       GUNICORN_BIND: 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       MAX_RESULTS: 10
       DISCLAIMER: 'This is a test PatientMatcher server'
       ADMINS: '["test@mail.se"]'
+      TESTING: True
       GUNICORN_WORKERS: 1
       GUNICORN_TREADS: 1
       GUNICORN_BIND: 0.0.0.0:8000

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -3,7 +3,7 @@ import os
 # Turns on debugging features in Flask
 DEBUG = os.getenv("DEBUG") or True
 
-# Set to False is app is a production app
+# Set to False is app if a production app
 TESTING = os.getenv("TESTING") or True
 
 # secret key:

--- a/patientMatcher/instance/config.py
+++ b/patientMatcher/instance/config.py
@@ -3,6 +3,9 @@ import os
 # Turns on debugging features in Flask
 DEBUG = os.getenv("DEBUG") or True
 
+# Set to False is app is a production app
+TESTING = os.getenv("TESTING") or True
+
 # secret key:
 SECRET_KEY = os.getenv("SECRET_KEY") or "MySuperSecretKey"
 

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import sys
+from pathlib import Path
 
 import coloredlogs
 from flask import Flask
@@ -18,11 +19,10 @@ LOG = logging.getLogger(__name__)
 
 def available_phenotype_resources():
     """Check that necessary resources (HPO terms and phenotype annotations) were downloaded and available"""
-    if (
-        os.path.isfile(path_to_hpo_terms) is False
-        or os.path.isfile(path_to_phenotype_annotations) is False
-    ):
-        return False
+    for filepath in [path_to_hpo_terms, path_to_phenotype_annotations]:
+        if Path(path_to_hpo_terms).is_file() is False:
+            return False
+
     return True
 
 
@@ -84,7 +84,8 @@ def create_app():
 
     # If it's not a test app and phenotype resources are missing
     # Display message and exit
-    if not any([app.config.get("TESTING"), available_phenotype_resources()]):
+
+    if app.config.get("TESTING") in ["False", False] and available_phenotype_resources() is False:
         LOG.error(
             "Required files hp.obo.txt and phenotype_annotation.tab.txt not found on the server. Please download them with the command 'pmatcher update resources'."
         )

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -33,7 +33,7 @@ def heartbeat(disclaimer):
 
     hbeat = {
         "heartbeat": {
-            "production": True,
+            "production": bool(current_app.config.get("TESTING") is False),
             "version": __version__,
             "accept": [
                 "application/vnd.ga4gh.matchmaker.v1.0+json",

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -33,7 +33,7 @@ def heartbeat(disclaimer):
 
     hbeat = {
         "heartbeat": {
-            "production": bool(current_app.config.get("TESTING") is False),
+            "production": bool(current_app.config.get("TESTING", "True") == "False"),
             "version": __version__,
             "accept": [
                 "application/vnd.ga4gh.matchmaker.v1.0+json",

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-from urllib.parse import urlparse
 
 from flask import current_app, jsonify
 from jsonschema import ValidationError

--- a/patientMatcher/server/controllers.py
+++ b/patientMatcher/server/controllers.py
@@ -33,7 +33,7 @@ def heartbeat(disclaimer):
 
     hbeat = {
         "heartbeat": {
-            "production": bool(current_app.config.get("TESTING", "True") == "False"),
+            "production": current_app.config.get("TESTING", "True") in ["False", False],
             "version": __version__,
             "accept": [
                 "application/vnd.ga4gh.matchmaker.v1.0+json",

--- a/tests/server/test_create_app.py
+++ b/tests/server/test_create_app.py
@@ -13,9 +13,12 @@ def test_create_app():
     assert create_app()
 
 
-def test_create_app_missing_requirement(mock_app):
+def test_create_app_missing_requirement(monkeypatch):
     """Tests the function that creates the app when phenotype_annotation.tab.txt and hp.obo.txt
     resources are missing"""
+
+    # GIVEN a prod server
+    monkeypatch.setenv("TESTING", False)
 
     # GIVEN one of the required files missing / it's been renamed
     temp_file = ".".join([path_to_hpo_terms, "temp"])

--- a/tests/server/test_create_app.py
+++ b/tests/server/test_create_app.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-from smtplib import SMTP
 
 from patientMatcher.resources import path_to_hpo_terms
 from patientMatcher.server import configure_email_error_logging, create_app

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -134,7 +134,7 @@ def test_heartbeat(mock_app, database, test_client):
     data = json.loads(response.data)
     assert data["disclaimer"] == mock_app.config.get("DISCLAIMER")
     assert data["heartbeat"]["version"] == __version__
-    assert isinstance(data["heartbeat"]["production"], bool)
+    assert data["heartbeat"]["production"] is False
     assert isinstance(data["heartbeat"]["accept"], list)
     assert len(data["heartbeat"]["accept"]) > 0
 

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 import json
 
-import pytest
-import requests
 from patientMatcher.__version__ import __version__
 from patientMatcher.auth.auth import authorize
 from patientMatcher.match.handler import patient_matches
 from patientMatcher.parse.patient import mme_patient
 from patientMatcher.server.controllers import validate_response
 from patientMatcher.utils.add import add_node, backend_add_patient, load_demo_patients
-from werkzeug.datastructures import Headers
 
 
 def test_match_async_request(mock_app, database, async_response_obj, json_patients, test_node):


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #254

### Expected outcome:
- [x] Master branch heartbeat should state that the demo instance is a prod server while this branch should return a stage instance

### Review:
- [x] Tests executed by GitHub actions, CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
