### PR TITLE
Speed-up CI tests by caching installation of libs and splitting tests into groups

### DIFF
--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -1,43 +1,88 @@
-name: Tests and coverage
+name: Run tests and push coverage to Codecov
 on: [push, pull_request]
+
 jobs:
-  Pytest_Codecov:
-    runs-on: ubuntu-18.04
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install deps
+        run: |
+          pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt -e .
+          pip check
+
+        # Cache package installation step to speed up the following step
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements-dev.txt') }}
+
+  test:
+    needs: setup
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        mongodb-version: ['3.2', '4.4', '5.0']
+        group: [1, 2, 3]
+        mongodb-version: ['4.4']
     env:
       PMATCHER_CONFIG: ../instance/config.py
-
     steps:
-    - name: Launch MongoDB
-      uses: wbari/start-mongoDB@v0.2
-      with:
-        mongoDBVersion: ${{ matrix.mongodb-version }}
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.7.0
+        with:
+         mongodb-version: ${{ matrix.mongodb-version }}
 
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@master
-      with:
-        python-version: 3.8
+      - uses: actions/checkout@v2
 
-    - name: Install repo and its dependencies
-      run: |
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-        pip install -e .
-        pip install pytest
-        pip install pytest-cov
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-    - name: Run pytest and codecov
-      run: |
-        pytest --cov=./ --cov-report=xml
+        # Cache package installation step to speed up the following step
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements-dev.txt') }}
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: unittests
-        env_vars: OS,PYTHON
-        name: codecov-umbrella
-        fail_ci_if_error: true
+      - name: Install deps
+        run: |
+          pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt -e .
+
+      - name: Run pytest
+        run: pytest --cov --test-group-count 3 --test-group=${{ matrix.group }} --test-group-random-seed=12345 --rootdir=/home/runner/work/scout
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage${{ matrix.group }}
+          path: .coverage
+
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install coverage
+      - name: Download all artifacts
+        # Download and combine coverage1, coverage2, etc.
+        uses: actions/download-artifact@v2
+      - name: Run coverage
+        run: |
+          coverage combine coverage*/.coverage*
+          coverage report
+          coverage xml
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -56,7 +56,7 @@ jobs:
           pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt -e .
 
       - name: Run pytest
-        run: pytest --cov --test-group-count 3 --test-group=${{ matrix.group }} --test-group-random-seed=12345 --rootdir=/home/runner/work/scout
+        run: pytest --cov --test-group-count 3 --test-group=${{ matrix.group }} --test-group-random-seed=12345
 
       - name: Upload coverage
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -1,5 +1,11 @@
 name: Run tests and push coverage to Codecov
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   setup:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+### Changed
+- Speed-up CI tests by caching installation of libs and splitting tests into randomized groups using pytest-test-groups
+
 ## [3.0] - 2021-12-27
 ### added
 - Index (landing page) reachable at endpoint `/`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # testing:
 click
 pytest
+pytest-test-groups
 mongomock
 pytest-cov
 coveralls


### PR DESCRIPTION
Fix #258 

### This PR adds | fixes:
- Speeds up testing and avoid sending coverage report to Codecov multiple times per PR

### How to test:
- Check the GitHub actions

### Expected outcome:
- [x] Tests should be successful

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions 
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
