### PR TITLE
Mock Ensembl services (gene conversion and liftover) used in patient parsing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Changed
 - Speed-up CI tests by caching installation of libs and splitting tests into randomized groups using pytest-test-groups
+- Mock Ensembl services (gene conversion and liftover) used in patient parsing tests
 
 ## [3.0] - 2021-12-27
 ### added

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from copy import deepcopy
-
 from patientMatcher.parse import patient
 
 

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -1,77 +1,109 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from patientMatcher.parse.patient import (
-    disorders_to_omim,
-    features_to_hpo,
-    gtfeatures_to_variants,
-    href_validate,
-    mme_patient,
-)
+from copy import deepcopy
+
+from patientMatcher.parse import patient
 
 
 def test_href_validate_wrong_url():
     """Test href_validate function with a malformed URL"""
-    assert href_validate("google") is False
+    assert patient.href_validate("google") is False
 
 
 def test_href_validate_valid_url():
     """Test href_validate function with a valid URL"""
-    assert href_validate("http://google.com") is True
+    assert patient.href_validate("http://google.com") is True
 
 
 def test_href_validate_wrong_email():
     """Test href_validate function with a mailto link and wrong email syntax"""
-    assert href_validate("me@patientmatcher.se") is False
+    assert patient.href_validate("me@patientmatcher.se") is False
 
 
 def test_href_validate_valid_email():
     """Test href_validate function with a mailto link and valid email"""
-    assert href_validate("mailto:me@patientmatcher.se") is True
+    assert patient.href_validate("mailto:me@patientmatcher.se") is True
 
 
 def test_features_to_hpo_no_features():
     """Make sure the function returns [] if patient doesn't have associated HPO terms"""
-    result = features_to_hpo(None)
+    result = patient.features_to_hpo(None)
     assert result == []
 
 
 def test_disorders_to_omim_no_omim():
     """Make sure the function returns [] if patient doesn't have associated OMIM terms"""
-    result = disorders_to_omim(None)
+    result = patient.disorders_to_omim(None)
     assert result == []
 
 
-def test_mme_patient_gene_symbol(gpx4_patients, database):
+def test_mme_patient_gene_symbol(gpx4_patients, database, monkeypatch):
     """Test format a patient with HGNC gene symbol"""
+
+    # GIVEN a patched gene conversion system mocking the Ensembl web services
+    def mock_symbol_to_ensembl(*args):
+        return "ENSG00000167468"
+
+    monkeypatch.setattr(patient, "symbol_to_ensembl", mock_symbol_to_ensembl)
 
     test_patient = gpx4_patients[0]
     gene_name = test_patient["genomicFeatures"][0]["gene"]["id"]  # "GPX4"
     # Before conversion patient's gene id is a gene symbol
     assert gene_name.startswith("ENSG") is False
-    mme_formatted_patient = mme_patient(test_patient, True)  # Convert gene symbol to Ensembl
+    mme_formatted_patient = patient.mme_patient(
+        test_patient, True
+    )  # Convert gene symbol to Ensembl
     # After conversion formatted patient's gene id should be an Ensembl id
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["id"].startswith("ENSG")
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["_geneName"] == gene_name
 
 
-def test_mme_patient_entrez_gene(entrez_gene_patient, database):
+def test_mme_patient_entrez_gene(entrez_gene_patient, database, monkeypatch):
     """Test format a patient with entrez gene"""
+
+    # GIVEN a patched gene conversion system mocking the Ensembl web services
+    def mock_symbol_to_ensembl(*args):
+        return "ENSG00000167468"
+
+    def mock_entrez_to_symbol(*args):
+        return "KARS"
+
+    monkeypatch.setattr(patient, "symbol_to_ensembl", mock_symbol_to_ensembl)
+    monkeypatch.setattr(patient, "entrez_to_symbol", mock_entrez_to_symbol)
+
     # Before conversion patient's gene id is an entrez gene ID
     assert entrez_gene_patient["genomicFeatures"][0]["gene"]["id"] == "3735"
-    mme_formatted_patient = mme_patient(entrez_gene_patient, True)  # convert genes to Ensembl
+    mme_formatted_patient = patient.mme_patient(
+        entrez_gene_patient, True
+    )  # convert genes to Ensembl
     # After conversion formatted patient's gene id should be an Ensembl id
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["id"].startswith("ENSG")
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["_geneName"]  # it's "KARS"
 
 
-def test_gtfeatures_to_variants(patient_37):
+def test_gtfeatures_to_variants(patient_37, monkeypatch):
     """Test the function that parses variants dictionaries from patient's genomic features"""
+
+    # GIVEN a mocked Ensembl REST API liftover service
+    def mock_liftover(*args):
+        mapped = {
+            "mapped": {
+                "assembly": "GRCh38",
+                "seq_region_name": "12",
+                "start": 14641141,
+                "end": 14641142,
+            }
+        }
+        return [mapped]
+
+    monkeypatch.setattr(patient, "liftover", mock_liftover)
+
     # GIVEN a patient containing 1 genomic feature (and one variant)
     gt_features = patient_37["patient"]["genomicFeatures"]
     assert len(gt_features) == 1
 
     # WHEN gtfeatures_to_variants is used to extract variants from gt_features
-    variants = gtfeatures_to_variants(gt_features)
+    variants = patient.gtfeatures_to_variants(gt_features)
 
     # THEN it should return 2 variants
     assert len(variants) == 2


### PR DESCRIPTION
Fix #157 --> Do not rely on Ensembl online web services when running patient parsing tests (gene conversions, variants liftover)

### How to test:
- [x] From master branch, disconnect from the internet and run the patient parsing tests: `pytest -x tests/parse/test_parse_patient.py` ---> They should fail
- [x] Switch to this branch and the tests should be successful
- [x] Automatic tests in GitHub actions should also work


### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
