### PR TITLE
Mock the download of files containing phenotype resources in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Changed
 - Speed-up CI tests by caching installation of libs and splitting tests into randomized groups using pytest-test-groups
 - Mock Ensembl services (gene conversion and liftover) used in patient parsing tests
+- Mock the download of files containing phenotype resources in tests
 
 ## [3.0] - 2021-12-27
 ### added

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -86,11 +86,7 @@ def resources(test):
         url = item["url"]
 
         r = requests.get(url, stream=True)
-
-        LOG.error("AFTER REQUEST")
         total_length = int(r.headers.get("content-length"))
-
-        LOG.error("AFTER LENGTH")
 
         if test:  # read file and get its size
             files[

--- a/patientMatcher/cli/update.py
+++ b/patientMatcher/cli/update.py
@@ -82,10 +82,16 @@ def resources(test):
     """
     files = {}
     for key, item in PHENOTYPE_TERMS.items():
-        url = item["url"]
         destination = item["resource_path"]
+        url = item["url"]
+
         r = requests.get(url, stream=True)
+
+        LOG.error("AFTER REQUEST")
         total_length = int(r.headers.get("content-length"))
+
+        LOG.error("AFTER LENGTH")
+
         if test:  # read file and get its size
             files[
                 key
@@ -93,6 +99,7 @@ def resources(test):
             if total_length:
                 click.echo("file {} found at the requested URL".format(key))
             continue
+
         with open(destination, "wb") as f:  # overwrite file
             for chunk in progress.bar(
                 r.iter_content(chunk_size=1024), expected_size=(total_length / 1024) + 1

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,8 +1,28 @@
+import responses
 from patientMatcher.cli.commands import cli
+from patientMatcher.constants import PHENOTYPE_TERMS
 
 
+@responses.activate
 def test_update_resources(mock_app):
     """Test the command that updates the database resources (diseases and HPO terms)"""
+
+    # Given a mocked response from the servers containing the resources to be downloaded
+    for key, item in PHENOTYPE_TERMS.items():
+
+        local_resource_path = item["resource_path"]  # Resource on the local repo
+        url = item["url"]  # Resource internet URL
+        with open(local_resource_path, "r") as res:
+            responses.add(
+                responses.GET,
+                url,
+                body=res.read(),
+                status=200,
+                content_type="application/octet-stream",
+                auto_calculate_content_length=True,
+                stream=True,
+            )
+
     runner = mock_app.test_cli_runner()
 
     # run resources update command with --test flag:

--- a/tests/parse/test_parse_patient.py
+++ b/tests/parse/test_parse_patient.py
@@ -35,7 +35,7 @@ def test_disorders_to_omim_no_omim():
     assert result == []
 
 
-def test_mme_patient_gene_symbol(gpx4_patients, database, monkeypatch):
+def test_mme_patient_gene_symbol(gpx4_patients, monkeypatch):
     """Test format a patient with HGNC gene symbol"""
 
     # GIVEN a patched gene conversion system mocking the Ensembl web services
@@ -56,7 +56,7 @@ def test_mme_patient_gene_symbol(gpx4_patients, database, monkeypatch):
     assert mme_formatted_patient["genomicFeatures"][0]["gene"]["_geneName"] == gene_name
 
 
-def test_mme_patient_entrez_gene(entrez_gene_patient, database, monkeypatch):
+def test_mme_patient_entrez_gene(entrez_gene_patient, monkeypatch):
     """Test format a patient with entrez gene"""
 
     # GIVEN a patched gene conversion system mocking the Ensembl web services


### PR DESCRIPTION
### This PR adds | fixes:
- Fixes the test that checks the availability of the phenotype resources online. Current main checks the file size of the online resources. In this branch the resources are mocked to point to the files present in this repo, in the "resources" folder.

### How to test:
- [x] Being in "main" branch, go offline and run `pytest -x tests/cli/test_update.py`, you should get an error
- [x] Switch to this branch and the tests should be successful

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
