### PR TITLE
Improve email error debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixed
+- Set MAIL_SUPPRESS_SEND to False and MAIL_DEBUG to True whenever app config has a MAIL_SERVER param
+
 ## [3.1.1] - 2022-01-15
 ### Fixed
 - Parsing of numerical and boolean env vars when creating the app

--- a/patientMatcher/cli/commands.py
+++ b/patientMatcher/cli/commands.py
@@ -118,10 +118,9 @@ def email(recipient):
         sender=current_app.config.get("MAIL_USERNAME"),
         recipients=[recipient],
     )
-    message = Message(**kwargs)
     try:
+        message = Message(**kwargs)
         current_app.mail.send(message)
-        click.echo("Mail correctly sent. Check your inbox!")
     except Exception as err:
         click.echo('An error occurred while sending test email: "{}"'.format(err))
 

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -96,6 +96,10 @@ def create_app():
     extensions.hpoic.init_app(app, extensions.hpo, extensions.diseases)
 
     if app.config.get("MAIL_SERVER"):
+
+        app.config["MAIL_SUPPRESS_SEND"] = False
+        app.config["MAIL_DEBUG"] = True
+
         mail = Mail(app)
         app.mail = mail
 


### PR DESCRIPTION
Fix #271 by setting `app.config["MAIL_SUPPRESS_SEND"]=False ` `and app.config["MAIL_DEBUG"]=True` whenever app conffig contain a param named "MAIL_SERVER"

This way the existence and value of app.TESTING param doesn't have influence on email sending

**How to prepare for test**:
- Install this branch on cg-vm1 and find out what's wrong with notifications (MAIL_DEBUG should be helpful there)

### How to test:
- Send a matching patient against one submitted using Scout

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
