### PR TITLE
Include db name in crash email report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+### Added
+- Name of database in crash report email, to understand if crashed app is stage or prod app
+
 ## [3.2] - 2022-01-21
 ### Changed
 - Colors and icons of landing page
@@ -19,7 +23,7 @@
 - Mock the download of files containing phenotype resources in tests
 
 ## [3.0] - 2021-12-27
-### added
+### Added
 - Index (landing page) reachable at endpoint `/`
 - Include software version in matching emails body
 ### Fixed

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -34,7 +34,7 @@ def configure_email_error_logging(app):
         mailhost=(app.config["MAIL_SERVER"], app.config["MAIL_PORT"]),
         fromaddr=app.config["MAIL_USERNAME"],
         toaddrs=app.config["ADMINS"],
-        subject=f"{app.name} log error",
+        subject=f"{app.name} - {app.config['DB_NAME']} - log error",
         credentials=(app.config["MAIL_USERNAME"], app.config["MAIL_PASSWORD"]),
     )
     mail_handler.setLevel(logging.ERROR)


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #279 

### How to test:
- Modify an endpoint to raise an error
- Modify config file with email params: server email, admin email, etc
- Launch the app and send a request to the endpoint that crashes

### Expected outcome:
- Email should be sent to admin and it should contain the name of the database in use

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
