### PR TITLE
Fixed ports used by app served using docker-compose in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [] -
+### Fixed
+- Ports used to serve the app in docker-compose howto
 ### Changed
 - Removed support for asynchronous requests to the server
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ docker-compose up -d
 The command will create 3 containers:
 - mongodb: starting a mongodb server with support for user authentication (--auth option)
 - patientmatcher_cli: the a command-line app, which will connect to the server and populates it with demo data
-- patientmatcher_web: a web server running on localhost and port 9020.
+- patientmatcher_web: a web server running on localhost and port 8000.
 
 The server will be running and accepting requests sent from outside the containers (another terminal or a web browser). Read further down to find out about requests and commands.
 
 To test server responses try to invoke the `metrics` endpoint with the following command:
 ```
-curl localhost:5000/metrics
+curl localhost:8000/metrics
 ```
 
 To stop the containers (and the server), run:


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #298 --> App is now served on [port 8000](https://github.com/Clinical-Genomics/patientMatcher/blob/1f89c4ac3dc0db2c9f0fd579b66dbca804746e02/docker-compose.yml#L54) using docker-compose 

### How to test:
- Run` docker-compose up`
- Then on another terminal: `curl localhost:8000/metrics`

### Expected outcome:
- [ ] App should return a valid response

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
