### PR TITLE
Display correct number of parsed diseases when server starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Security hotspots flagged by SonarCloud
 - Decreased vulnerability by removing some server log messages
 - Problems flagged as bugs by SonarCloud
+- Server startup debug message showing correct number of parsed diseases
 
 ## [4.1] - 2022-06-27
 ### Added

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -95,8 +95,8 @@ def create_app():
         )
         return
 
-    extensions.hpo.init_app(app)
-    extensions.diseases.init_app(app)
+    extensions.hpo.init_app()
+    extensions.diseases.init_app()
     extensions.hpoic.init_app(app, extensions.hpo, extensions.diseases)
 
     if app.config.get("MAIL_SERVER"):

--- a/patientMatcher/utils/disease.py
+++ b/patientMatcher/utils/disease.py
@@ -50,7 +50,7 @@ class Diseases:
     Resources included in this file: DECIPHER, OMIM, ORPHANET
     """
 
-    def init_app(self, app):
+    def init_app(self):
         """Initialize the diseases object when the app is launched"""
         self.databases = ["DECIPHER", "OMIM", "ORPHA"]
         self.diseases = {}

--- a/patientMatcher/utils/disease.py
+++ b/patientMatcher/utils/disease.py
@@ -55,7 +55,7 @@ class Diseases:
         self.databases = ["DECIPHER", "OMIM", "ORPHA"]
         self.diseases = {}
         self._parse_diseases()
-        LOG.info(f"Parsed {len(self.diseases.keys())} disease/phenotypes from resource file")
+        LOG.info(f"Parsed {len(self.diseases)} disease/phenotypes from resource file")
 
     def _parse_disease_frequency(self, field):
         """Parse disease frequency (col 8 in phenotype anno file)"""

--- a/patientMatcher/utils/hpo.py
+++ b/patientMatcher/utils/hpo.py
@@ -73,7 +73,7 @@ class HPNode(object):
 class HPO(object):
     """Parse and HPO ontology to make it available for phenotype matching"""
 
-    def init_app(self, app):
+    def init_app(self):
         """Initialize the HPO ontology when the app is launched."""
         self.hps = {}
         self._parse_ontolology()


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #313 - it's not a bug, just an error in the log message!

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/28093618/191694080-efdeb341-8d5f-453d-8af2-8b68a3a0c298.png">



### How to test:
- Locally, start the server on main branch and this branch and make sure that a number of parsed disease is shown when using this branch

### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
