### PR TITLE
Abort if phenotype terms are not correctly parsed from files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+### Changed
+- Abort server startup if phenotypes terms are not correctly parse from resource files
 ### Fixed
 - Parsing and downloading of the HPO definitions in the new format (`phenotype.hpoa`)
 - Replaced deprecated version of Ubuntu in GitHub actions

--- a/patientMatcher/server/__init__.py
+++ b/patientMatcher/server/__init__.py
@@ -91,7 +91,7 @@ def create_app():
     # If phenotype resources are missing display error and exit
     if available_phenotype_resources() is False:
         LOG.error(
-            "Required files hp.obo.txt and phenotype_annotation.tab.txt not found on the server. Please download them with the command 'pmatcher update resources'."
+            "Required files hp.obo.txt and phenotype.hpoa not found on the server. Please download them with the command 'pmatcher update resources'."
         )
         return
 
@@ -99,8 +99,12 @@ def create_app():
     extensions.diseases.init_app()
     extensions.hpoic.init_app(app, extensions.hpo, extensions.diseases)
 
-    if app.config.get("MAIL_SERVER"):
+    for terms in [extensions.hpo.hps, extensions.diseases.diseases]:
+        if not terms:
+            LOG.error("An error occurred while parsing resource files.")
+            return
 
+    if app.config.get("MAIL_SERVER"):
         app.config["MAIL_SUPPRESS_SEND"] = False
         app.config["MAIL_DEBUG"] = True
 


### PR DESCRIPTION
### This PR adds | fixes:
- FIx #319 

### How to test:
- Try to start the app with empty resource files

### Expected outcome:
- [x] From main branch app should start, but not from this branch

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
