### PR TITLE
generalize mongodb version in tests and docker-compose

### DIFF
--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         group: [1, 2, 3]
-        mongodb-version: ['4.4']
+        mongodb-version: ['7.0.2']
     env:
       PMATCHER_CONFIG: ../instance/config.py
     steps:

--- a/.github/workflows/pytest_codecov.yml
+++ b/.github/workflows/pytest_codecov.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         group: [1, 2, 3]
-        mongodb-version: ['7.0.2']
+        mongodb-version: ['7']
     env:
       PMATCHER_CONFIG: ../instance/config.py
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+## Changed
+- Unfreeze PyMongo dependency
+
 ## [4.4] - 2023-08-14
 ### Added
 - Option to display the description of the connected nodes on the index page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [unreleased]
 ## Changed
 - Unfreeze PyMongo dependency
+- Use MongoDB version 7.0.2 in docker-compose.yml
 
 ## [4.4] - 2023-08-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [unreleased]
 ## Changed
 - Unfreeze PyMongo dependency
-- Use MongoDB version 7.0.2 in docker-compose.yml
-- Execute tests using MongoDB 7.0.2
+- Use MongoDB version 7 in docker-compose.yml
+- Execute tests using MongoDB 7
 
 ## [4.4] - 2023-08-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Changed
 - Unfreeze PyMongo dependency
 - Use MongoDB version 7.0.2 in docker-compose.yml
+- Execute tests using MongoDB 7.0.2
 
 ## [4.4] - 2023-08-14
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 # sudo docker-compose up
 services:
   mongodb:
-    # Using the official MongoDB image 4.4.9
+    # Using the official MongoDB image 7
     image: mongo:7
     container_name: mongodb
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3'
 services:
   mongodb:
     # Using the official MongoDB image 4.4.9
-    image: mongo:7.0.2
+    image: mongo:7
     container_name: mongodb
     networks:
       - pmatcher-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3'
 services:
   mongodb:
     # Using the official MongoDB image 4.4.9
-    image: mongo:4.4.9
+    image: mongo:7.0.2
     container_name: mongodb
     networks:
       - pmatcher-net

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ responses
 jsonschema
 
 ## database connection
-pymongo<4.0
+pymongo
 
 ##backend
 enlighten


### PR DESCRIPTION
### This PR adds | fixes:
- Unfreeze pymongo lib and upgrade MongoDB version to 7 in tests and docker-compose 


### How to test:
- Run docker-compose up and make sure the demo database gets populated

### Expected outcome:
- [ ] Unfreeze pymongo and modify tests to run with latest MongoDB version

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
