### PR TITLE
Fix new additionalContacts patient's parsing and saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Conftest file to reflect a patient's contact with email, roles and additionalContacts (#383)
 ### Fixed
 - Fixed typo on conda installation docs (#373)
-- Parsing and saving `additionalContacts` field when a patient is saved using the endpoint ()
+- Parsing and saving `additionalContacts` field when a patient is saved using the endpoint (#386)
 
 ## [4.6.1] - 2025-07-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 ### Added
 - `email`, `additionalContacts` and `roles` in API reference json schema (#380 and #384)
 - Allow assigning contact `roles` using the cli (#383)
-- A test to make sure 
 ### Changed
 - Updated versions of external actions and MongoDB in GitHub workflows (#374)
 - Allow updating contact's email and href separately using the command line (#381)
 - Conftest file to reflect a patient's contact with email, roles and additionalContacts (#383)
 ### Fixed
 - Fixed typo on conda installation docs (#373)
+- Parsing and saving `additionalContacts` field when a patient is saved using the endpoint ()
 
 ## [4.6.1] - 2025-07-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - `email`, `additionalContacts` and `roles` in API reference json schema (#380 and #384)
 - Allow assigning contact `roles` using the cli (#383)
+- A test to make sure 
 ### Changed
 - Updated versions of external actions and MongoDB in GitHub workflows (#374)
 - Allow updating contact's email and href separately using the command line (#381)

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -58,6 +58,7 @@ def mme_patient(json_patient, convert_to_ensembl=False):
         "label": json_patient.get("label"),
         "sex": json_patient.get("sex"),
         "contact": json_patient["contact"],
+        "additionalContacts": json_patient["additionalContacts"],
         "features": json_patient.get("features"),
         "genomicFeatures": json_patient.get("genomicFeatures"),
         "disorders": json_patient.get("disorders"),

--- a/patientMatcher/parse/patient.py
+++ b/patientMatcher/parse/patient.py
@@ -58,7 +58,6 @@ def mme_patient(json_patient, convert_to_ensembl=False):
         "label": json_patient.get("label"),
         "sex": json_patient.get("sex"),
         "contact": json_patient["contact"],
-        "additionalContacts": json_patient["additionalContacts"],
         "features": json_patient.get("features"),
         "genomicFeatures": json_patient.get("genomicFeatures"),
         "disorders": json_patient.get("disorders"),
@@ -66,6 +65,9 @@ def mme_patient(json_patient, convert_to_ensembl=False):
         "ageOfOnset": json_patient.get("ageOfOnset"),
         "inheritanceMode": json_patient.get("inheritanceMode"),
     }
+
+    if json_patient.get("additionalContacts"):
+        mme_patient["additionalContacts"] = json_patient["additionalContacts"]
 
     # remove keys with empty values from mme_patient object
     mme_patient = {k: v for k, v in mme_patient.items() if v is not None}

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -193,7 +193,7 @@ def test_update_patient(mock_app, test_client, gpx4_patients, test_node, databas
     # and an empty patients collection
     assert database["patients"].find_one() is None
 
-    # GIVEN a patient added using the add enpoint
+    # GIVEN a patient added using the add endpoint
     patient_obj = {"patient": patient_data}  # this is a valid patient object
     response = mock_app.test_client().post(
         ADD_PATIENT_ENDPOINT, data=json.dumps(patient_obj), headers=auth_headers(ok_token)

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -91,6 +91,7 @@ def test_add_patient_malformed_data(mock_app, test_client, gpx4_patients, test_n
     # and check that the server returns an error 422 (unprocessable entity)
     assert response.status_code == 422
 
+
 def _setup(mock_app, test_client, test_node, database):
     # common setup used in all tests
     ok_token = test_client["auth_token"]

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -91,131 +91,92 @@ def test_add_patient_malformed_data(mock_app, test_client, gpx4_patients, test_n
     # and check that the server returns an error 422 (unprocessable entity)
     assert response.status_code == 422
 
+def _setup(mock_app, test_client, test_node, database):
+    # common setup used in all tests
+    ok_token = test_client["auth_token"]
+
+    add_node(mongo_db=mock_app.db, obj=test_client, is_client=True)
+    add_node(mongo_db=mock_app.db, obj=test_node, is_client=False)
+
+    assert database["matches"].find_one() is None
+    assert database["patients"].find_one() is None
+
+    return ok_token
+
 
 @responses.activate
 def test_add_patient_from_demo_data(
     mock_app, test_client, gpx4_patients, test_node, database, mocked_ensemble_responses
 ):
-    """Test adding a patient by sending a POST request to the add endpoint with valid data"""
-
     patient_data = gpx4_patients[1]
+    ok_token = _setup(mock_app, test_client, test_node, database)
 
-    # Given a node with authorized token
-    ok_token = test_client["auth_token"]
-
-    add_node(mongo_db=mock_app.db, obj=test_client, is_client=True)
-    add_node(
-        mongo_db=mock_app.db, obj=test_node, is_client=False
-    )  # add a test node, to perform external matching
-
-    # a matches collection without documents
-    assert database["matches"].find_one() is None
-
-    # and an empty patients collection
-    assert database["patients"].find_one() is None
-
-    patient_obj = {"patient": patient_data}  # this is a valid patient object
-    # WHEN the patient is added using the add endpoint
     response = mock_app.test_client().post(
-        ADD_PATIENT_ENDPOINT, data=json.dumps(patient_obj), headers=auth_headers(ok_token)
+        ADD_PATIENT_ENDPOINT,
+        data=json.dumps({"patient": patient_data}),
+        headers=auth_headers(ok_token),
     )
     assert response.status_code == 200
 
-    # make sure that the POST request to add the patient triggers the matching request to an external node
     assert database["matches"].find_one()
-
-    # There should be one patient in database now
     assert database["patients"].find_one()
 
-    # the patient in database has label "Patient number 1"
     result = database["patients"].find_one({"label": "350_2-test"})
-    # make sure patient's gene was converted to ensembl
-    assert result["genomicFeatures"][0]["gene"]["id"].startswith("ENSG")
-    # and that non-standard but informative _geneName field was added to genomic feature
-    assert result["genomicFeatures"][0]["gene"]["_geneName"] == "GPX4"
+    gene = result["genomicFeatures"][0]["gene"]
+
+    assert gene["id"].startswith("ENSG")
+    assert gene["_geneName"] == "GPX4"
 
 
 @responses.activate
 def test_add_one_patient_with_additional_contacts(
     mock_app, test_client, entrez_gene_patient, test_node, database, mocked_ensemble_responses
 ):
-    """Test adding a patient containing the additionalContacts field by sending a POST request to the add endpoint with valid data."""
-
     patient_data = entrez_gene_patient
+    ok_token = _setup(mock_app, test_client, test_node, database)
 
-    # Given a node with authorized token
-    ok_token = test_client["auth_token"]
-
-    add_node(mongo_db=mock_app.db, obj=test_client, is_client=True)
-    add_node(
-        mongo_db=mock_app.db, obj=test_node, is_client=False
-    )  # add a test node, to perform external matching
-
-    # a matches collection without documents
-    assert database["matches"].find_one() is None
-
-    # and an empty patients collection
-    assert database["patients"].find_one() is None
-
-    patient_obj = {"patient": patient_data}  # this is a valid patient object
-    # WHEN the patient is added using the add endpoint
     response = mock_app.test_client().post(
-        ADD_PATIENT_ENDPOINT, data=json.dumps(patient_obj), headers=auth_headers(ok_token)
+        ADD_PATIENT_ENDPOINT,
+        data=json.dumps({"patient": patient_data}),
+        headers=auth_headers(ok_token),
     )
     assert response.status_code == 200
 
-    # make sure that the POST request to add the patient triggers the matching request to an external node
     assert database["matches"].find_one()
 
-    # There should be one patient in database now
     result = database["patients"].find_one()
     assert result["additionalContacts"]
 
 
 def test_update_patient(mock_app, test_client, gpx4_patients, test_node, database):
-    """Test updating a patient by sending a POST request to the add endpoint with valid data"""
-
     patient_data = gpx4_patients[1]
-    # Modify patient's contact href with a simple email
     patient_data["contact"]["href"] = "somebody@test.se"
 
-    # Given a node with authorized token
-    ok_token = test_client["auth_token"]
+    ok_token = _setup(mock_app, test_client, test_node, database)
 
-    add_node(mongo_db=mock_app.db, obj=test_client, is_client=True)
-    add_node(
-        mongo_db=mock_app.db, obj=test_node, is_client=False
-    )  # add a test node, to perform external matching
-
-    # a matches collection without documents
-    assert database["matches"].find_one() is None
-
-    # and an empty patients collection
-    assert database["patients"].find_one() is None
-
-    # GIVEN a patient added using the add endpoint
-    patient_obj = {"patient": patient_data}  # this is a valid patient object
+    # initial add
     response = mock_app.test_client().post(
-        ADD_PATIENT_ENDPOINT, data=json.dumps(patient_obj), headers=auth_headers(ok_token)
+        ADD_PATIENT_ENDPOINT,
+        data=json.dumps({"patient": patient_data}),
+        headers=auth_headers(ok_token),
     )
     assert response.status_code == 200
 
-    # WHEN the patient is updated using the same add endpoint
+    # update
     patient_data["label"] = "modified patient label"
-    patient_obj = {"patient": patient_data}  # this
     response = mock_app.test_client().post(
-        ADD_PATIENT_ENDPOINT, data=json.dumps(patient_obj), headers=auth_headers(ok_token)
+        ADD_PATIENT_ENDPOINT,
+        data=json.dumps({"patient": patient_data}),
+        headers=auth_headers(ok_token),
     )
     assert response.status_code == 200
 
-    # Then there should still be one patient in the database
     updated_patient = database["patients"].find_one()
-    # With an updated and valid email address
+
     assert updated_patient["contact"]["href"] == "mailto:somebody@test.se"
 
-    # And the update has triggered an additional external patient matching
-    results = database["matches"].find()
-    assert len(list(results)) == 2
+    results = list(database["matches"].find())
+    assert len(results) == 2
 
 
 def test_metrics(mock_app, database, test_client, demo_data_path, match_objs):

--- a/tests/server/test_server_responses.py
+++ b/tests/server/test_server_responses.py
@@ -93,7 +93,7 @@ def test_add_patient_malformed_data(mock_app, test_client, gpx4_patients, test_n
 
 
 @responses.activate
-def test_add_patient(
+def test_add_patient_from_demo_data(
     mock_app, test_client, gpx4_patients, test_node, database, mocked_ensemble_responses
 ):
     """Test adding a patient by sending a POST request to the add endpoint with valid data"""
@@ -115,7 +115,7 @@ def test_add_patient(
     assert database["patients"].find_one() is None
 
     patient_obj = {"patient": patient_data}  # this is a valid patient object
-    # WHEN the patient is added using the add enpoint
+    # WHEN the patient is added using the add endpoint
     response = mock_app.test_client().post(
         ADD_PATIENT_ENDPOINT, data=json.dumps(patient_obj), headers=auth_headers(ok_token)
     )
@@ -133,6 +133,43 @@ def test_add_patient(
     assert result["genomicFeatures"][0]["gene"]["id"].startswith("ENSG")
     # and that non-standard but informative _geneName field was added to genomic feature
     assert result["genomicFeatures"][0]["gene"]["_geneName"] == "GPX4"
+
+
+@responses.activate
+def test_add_one_patient_with_additional_contacts(
+    mock_app, test_client, entrez_gene_patient, test_node, database, mocked_ensemble_responses
+):
+    """Test adding a patient containing the additionalContacts field by sending a POST request to the add endpoint with valid data."""
+
+    patient_data = entrez_gene_patient
+
+    # Given a node with authorized token
+    ok_token = test_client["auth_token"]
+
+    add_node(mongo_db=mock_app.db, obj=test_client, is_client=True)
+    add_node(
+        mongo_db=mock_app.db, obj=test_node, is_client=False
+    )  # add a test node, to perform external matching
+
+    # a matches collection without documents
+    assert database["matches"].find_one() is None
+
+    # and an empty patients collection
+    assert database["patients"].find_one() is None
+
+    patient_obj = {"patient": patient_data}  # this is a valid patient object
+    # WHEN the patient is added using the add endpoint
+    response = mock_app.test_client().post(
+        ADD_PATIENT_ENDPOINT, data=json.dumps(patient_obj), headers=auth_headers(ok_token)
+    )
+    assert response.status_code == 200
+
+    # make sure that the POST request to add the patient triggers the matching request to an external node
+    assert database["matches"].find_one()
+
+    # There should be one patient in database now
+    result = database["patients"].find_one()
+    assert result["additionalContacts"]
 
 
 def test_update_patient(mock_app, test_client, gpx4_patients, test_node, database):


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Parsing and saving additionalContacts when patient is saved via the endpoint

### How to test
- [x] Automatic new test


## Review
- [x] Tests executed by GitHub actions
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions